### PR TITLE
Add sentence parser test infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,22 @@ jobs:
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
           CI_TARGET_DEVICE: ${{ matrix.target_device }}
+
+  test-build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+          - pioarduino_esp32
+          - pioarduino_esp32c3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+      - name: Build tests
+        run: pio test -e ${{ matrix.env }} --without-uploading --without-testing

--- a/test/README
+++ b/test/README
@@ -1,11 +1,18 @@
 
-This directory is intended for PlatformIO Unit Testing and project tests.
+PlatformIO Unit Tests for SensESP NMEA0183
 
-Unit Testing is a software testing method by which individual units of
-source code, sets of one or more MCU program modules together with associated
-control data, usage procedures, and operating procedures, are tested to
-determine whether they are fit for use. Unit testing finds problems early
-in the development cycle.
+Tests are organized by component under test/ subdirectories:
 
-More information about PlatformIO Unit Testing:
-- https://docs.platformio.org/page/plus/unit-testing.html
+  test/test_sentence_parser/  - Sentence parser tests
+
+Building tests (no hardware required):
+
+  pio test -e pioarduino_esp32 --without-uploading --without-testing
+
+Running tests on device:
+
+  pio test -e pioarduino_esp32
+
+Tests compile for the ESP32 target and use the Unity test framework. Each test
+file creates NMEA0183Parser instances, registers sentence parsers, feeds known
+NMEA sentences, and asserts the parsed output values.

--- a/test/test_sentence_parser/test_gga.cpp
+++ b/test/test_sentence_parser/test_gga.cpp
@@ -1,0 +1,96 @@
+#include <unity.h>
+
+#include "sensesp_nmea0183/nmea0183.h"
+#include "sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h"
+
+using namespace sensesp;
+using namespace sensesp::nmea0183;
+
+static NMEA0183Parser* parser;
+static GGASentenceParser* gga;
+
+void setUp(void) {
+  parser = new NMEA0183Parser();
+  gga = new GGASentenceParser(parser);
+}
+
+void tearDown(void) {
+  delete gga;
+  delete parser;
+}
+
+void test_gga_valid_sentence(void) {
+  // Real-world GGA sentence
+  parser->set(
+      "$GNGGA,121042.00,6011.07385,N,02503.04396,E,2,11,1.04,17.0,M,17.6,M,,"
+      "0000*75");
+
+  Position pos = gga->position_.get();
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 60.1845, pos.latitude);
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 25.0507, pos.longitude);
+  TEST_ASSERT_EQUAL_INT(2, gga->quality_.get());
+  TEST_ASSERT_EQUAL_STRING("DGNSS fix", gga->gnss_quality_.get().c_str());
+  TEST_ASSERT_EQUAL_INT(11, gga->num_satellites_.get());
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 1.04, gga->horizontal_dilution_.get());
+  TEST_ASSERT_FLOAT_WITHIN(0.1, 17.0, gga->position_.get().altitude);
+  TEST_ASSERT_FLOAT_WITHIN(0.1, 17.6, gga->geoidal_separation_.get());
+  TEST_ASSERT_EQUAL_INT(1, gga->get_rx_count());
+}
+
+void test_gga_no_fix_returns_false(void) {
+  // GGA with no fix has empty position fields — non-optional field parsers
+  // fail, so parse_fields returns false and rx_count does not increment.
+  int rx_before = gga->get_rx_count();
+  parser->set(
+      "$GNGGA,121224.00,,,,,,0,00,99.99,,,,,,*7E");
+
+  TEST_ASSERT_EQUAL_INT(rx_before, gga->get_rx_count());
+}
+
+void test_gga_invalid_checksum(void) {
+  // Sentence with wrong checksum — should not parse
+  int rx_before = gga->get_rx_count();
+  parser->set(
+      "$GNGGA,121042.00,6011.07385,N,02503.04396,E,2,11,1.04,17.0,M,17.6,M,,"
+      "0000*FF");
+
+  TEST_ASSERT_EQUAL_INT(rx_before, gga->get_rx_count());
+}
+
+void test_gga_rx_count_increments(void) {
+  parser->set(
+      "$GNGGA,121042.00,6011.07385,N,02503.04396,E,2,11,1.04,17.0,M,17.6,M,,"
+      "0000*75");
+  parser->set(
+      "$GNGGA,121042.00,6011.07385,N,02503.04396,E,2,11,1.04,17.0,M,17.6,M,,"
+      "0000*75");
+
+  TEST_ASSERT_EQUAL_INT(2, gga->get_rx_count());
+}
+
+#ifdef ARDUINO
+void setup() {
+  delay(2000);
+  UNITY_BEGIN();
+
+  RUN_TEST(test_gga_valid_sentence);
+  RUN_TEST(test_gga_no_fix_returns_false);
+  RUN_TEST(test_gga_invalid_checksum);
+  RUN_TEST(test_gga_rx_count_increments);
+
+  UNITY_END();
+}
+
+void loop() {}
+#else
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_gga_valid_sentence);
+  RUN_TEST(test_gga_no_fix_returns_false);
+  RUN_TEST(test_gga_invalid_checksum);
+  RUN_TEST(test_gga_rx_count_increments);
+
+  return UNITY_END();
+}
+#endif


### PR DESCRIPTION
## Summary

- Set up PlatformIO Unity test framework for NMEA 0183 sentence parsers
- Add example GGA parser test with 4 test cases (valid parse, no-fix rejection, invalid checksum, rx counter)
- Add CI job to build tests for both ESP32 and ESP32-C3 targets
- Tests compile for embedded targets and run on hardware via `pio test`

This is a prerequisite for adding new sentence parsers (DBT, MTW, HDM, HDT, GSA, ZDA, MWD, VWR, RMB, APB, BWC, WPL, RTE, MDA, GBS) — each new parser PR will include tests.

## Test plan

- [x] Tests build for `pioarduino_esp32`
- [x] Tests build for `pioarduino_esp32c3`
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)