### PR TITLE
Fix MWV parser to accept any talker ID and add true wind support

### DIFF
--- a/src/sensesp_nmea0183/nmea0183.cpp
+++ b/src/sensesp_nmea0183/nmea0183.cpp
@@ -87,7 +87,7 @@ void NMEA0183Parser::parse_sentence(const String& sentence) {
       bool result = parser->parse(sentence_str);
       ESP_LOGV("SensESP/NMEA0183", "Parsed sentence %s with result %s",
                sentence_str, result ? "true" : "false");
-      return;
+      if (result) return;
     }
   }
   ESP_LOGV("SensESP/NMEA0183", "No parser found for sentence %s", sentence_str);

--- a/src/sensesp_nmea0183/sentence_parser/field_parsers.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/field_parsers.cpp
@@ -172,4 +172,26 @@ bool ParseEmpty(const char* s) {
   return s[0] == 0;
 }
 
+bool ConvertSpeedToMs(float* speed, char unit) {
+  float conv_ratio;
+  switch (unit) {
+    case 'K':  // km/h
+      conv_ratio = 0.277778;
+      break;
+    case 'M':  // m/s
+      conv_ratio = 1.0;
+      break;
+    case 'N':  // knots
+      conv_ratio = 0.514444;
+      break;
+    case 'S':  // statute miles/h
+      conv_ratio = 0.44704;
+      break;
+    default:
+      return false;
+  }
+  *speed *= conv_ratio;
+  return true;
+}
+
 }  // namespace sensesp::nmea0183

--- a/src/sensesp_nmea0183/sentence_parser/field_parsers.h
+++ b/src/sensesp_nmea0183/sentence_parser/field_parsers.h
@@ -32,6 +32,10 @@ bool ParseDate(int* year, int* month, int* day, const char* s,
 
 bool ParseEmpty(const char* s);
 
+/// Convert a speed value to m/s given its NMEA unit character.
+/// Returns false if the unit is unrecognized.
+bool ConvertSpeedToMs(float* speed, char unit);
+
 // Field parser macro that can be used to define sentence parsers as arrays of
 // field parsers.
 

--- a/src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.cpp
@@ -4,18 +4,18 @@
 
 namespace sensesp::nmea0183 {
 
-bool WIMWVSentenceParser::parse_fields(const char* field_strings,
-                                       const int field_offsets[],
-                                       int num_fields) {
+bool MWVSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
   bool ok = true;
 
   float wind_speed;
   float wind_angle;
 
   //      0,  1,2,  3,4,5
-  // $WIMWV,a.a,R,s.s,N,A*hhhh<CR><LF>
+  // $xxMWV,a.a,R,s.s,N,A*hh
   // where a.a is the apparent wind angle in degrees
-  //       s.s is the relative wind speed in knots
+  //       s.s is the wind speed
 
   if (num_fields < 6) {
     return false;
@@ -45,36 +45,62 @@ bool WIMWVSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  // K = km/hr
-  // M = m/s
-  // N = knots
-  // S = statute miles/hr
-
-  float conv_ratio = 1.0;
-  switch (units) {
-    case 'K':
-      conv_ratio = 0.277778;
-      break;
-    case 'M':
-      conv_ratio = 1.0;
-      break;
-    case 'N':
-      conv_ratio = 0.514444;
-      break;
-    case 'S':
-      conv_ratio = 0.44704;
-      break;
-    default:
-      return false;
+  if (!ConvertSpeedToMs(&wind_speed, units)) {
+    return false;
   }
 
-  wind_speed *= conv_ratio;
-
   apparent_wind_speed_.set(wind_speed);
+  apparent_wind_angle_.set(wind_angle * DEG_TO_RAD);
 
-  // convert wind angle to radians
-  wind_angle = wind_angle * DEG_TO_RAD;
-  apparent_wind_angle_.set(wind_angle);
+  return true;
+}
+
+bool TrueWindMWVSentenceParser::parse_fields(const char* field_strings,
+                                              const int field_offsets[],
+                                              int num_fields) {
+  bool ok = true;
+
+  float wind_speed;
+  float wind_angle;
+
+  //      0,  1,2,  3,4,5
+  // $xxMWV,a.a,T,s.s,N,A*hh
+  // where a.a is the true wind direction in degrees
+  //       s.s is the wind speed
+
+  if (num_fields < 6) {
+    return false;
+  }
+
+  char t_value;
+  char units;
+  char a_value;
+
+  std::function<bool(const char*)> fps[] = {// 1 a.a = True wind direction
+                                            FLDP_OPT(Float, &wind_angle),
+                                            // 2 T = True wind
+                                            FLDP_OPT(Char, &t_value, 'T'),
+                                            // 3 s.s = Wind speed
+                                            FLDP_OPT(Float, &wind_speed),
+                                            // 4 N = Wind speed units
+                                            FLDP_OPT(Char, &units, 255),
+                                            // 5 A = Valid
+                                            FLDP_OPT(Char, &a_value, 'A')};
+
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (!ConvertSpeedToMs(&wind_speed, units)) {
+    return false;
+  }
+
+  true_wind_speed_.set(wind_speed);
+  true_wind_direction_.set(wind_angle * DEG_TO_RAD);
 
   return true;
 }

--- a/src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.h
+++ b/src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.h
@@ -8,17 +8,30 @@
 
 namespace sensesp::nmea0183 {
 
-/// Parser for WIMWV (Wind Speed and Angle) sentences
-class WIMWVSentenceParser : public SentenceParser {
+/// Parser for MWV (Wind Speed and Angle) sentences — apparent wind (R reference)
+class MWVSentenceParser : public SentenceParser {
  public:
-  WIMWVSentenceParser(NMEA0183Parser* nmea)
+  MWVSentenceParser(NMEA0183Parser* nmea)
       : SentenceParser(nmea) {}
   bool parse_fields(const char* field_strings, const int field_offsets[],
                     int num_fields) override final;
-  const char* sentence_address() override { return "WIMWV"; }
+  const char* sentence_address() override { return "..MWV"; }
 
   ObservableValue<float> apparent_wind_speed_;
   ObservableValue<float> apparent_wind_angle_;
+};
+
+/// Parser for MWV (Wind Speed and Angle) sentences — true wind (T reference)
+class TrueWindMWVSentenceParser : public SentenceParser {
+ public:
+  TrueWindMWVSentenceParser(NMEA0183Parser* nmea)
+      : SentenceParser(nmea) {}
+  bool parse_fields(const char* field_strings, const int field_offsets[],
+                    int num_fields) override final;
+  const char* sentence_address() override { return "..MWV"; }
+
+  ObservableValue<float> true_wind_direction_;  // radians
+  ObservableValue<float> true_wind_speed_;      // m/s
 };
 
 /// Parser for MWD (Wind Direction and Speed, True) sentences

--- a/src/sensesp_nmea0183/wiring.cpp
+++ b/src/sensesp_nmea0183/wiring.cpp
@@ -167,11 +167,11 @@ void ConnectQuectelRTK(NMEA0183Parser* nmea_input, RTKData* rtk_data) {
 
 void ConnectApparentWind(NMEA0183Parser* nmea_input,
                          ApparentWindData* apparent_wind_data) {
-  auto* wimwv = new WIMWVSentenceParser(nmea_input);
+  auto* mwv = new MWVSentenceParser(nmea_input);
   auto* vwr = new VWRSentenceParser(nmea_input);
 
-  wimwv->apparent_wind_speed_.connect_to(&apparent_wind_data->speed);
-  wimwv->apparent_wind_angle_.connect_to(&apparent_wind_data->angle);
+  mwv->apparent_wind_speed_.connect_to(&apparent_wind_data->speed);
+  mwv->apparent_wind_angle_.connect_to(&apparent_wind_data->angle);
 
   vwr->apparent_wind_speed_.connect_to(&apparent_wind_data->speed);
   vwr->apparent_wind_angle_.connect_to(&apparent_wind_data->angle);
@@ -213,9 +213,13 @@ void ConnectHeading(NMEA0183Parser* nmea_input, HeadingData* data) {
 
 void ConnectTrueWind(NMEA0183Parser* nmea_input, TrueWindData* data) {
   auto* mwd = new MWDSentenceParser(nmea_input);
+  auto* mwv_true = new TrueWindMWVSentenceParser(nmea_input);
 
   mwd->true_wind_direction_.connect_to(&data->direction);
   mwd->true_wind_speed_.connect_to(&data->speed);
+
+  mwv_true->true_wind_direction_.connect_to(&data->direction);
+  mwv_true->true_wind_speed_.connect_to(&data->speed);
 
   data->direction.connect_to(new SKOutputFloat(
       "environment.wind.directionTrue", "/SK Path/True Wind Direction"));

--- a/test/test_mwd_vwr/test_mwd_vwr.cpp
+++ b/test/test_mwd_vwr/test_mwd_vwr.cpp
@@ -9,14 +9,20 @@ using namespace sensesp::nmea0183;
 static NMEA0183Parser* parser;
 static MWDSentenceParser* mwd;
 static VWRSentenceParser* vwr;
+static MWVSentenceParser* mwv;
+static TrueWindMWVSentenceParser* mwv_true;
 
 void setUp(void) {
   parser = new NMEA0183Parser();
   mwd = new MWDSentenceParser(parser);
   vwr = new VWRSentenceParser(parser);
+  mwv = new MWVSentenceParser(parser);
+  mwv_true = new TrueWindMWVSentenceParser(parser);
 }
 
 void tearDown(void) {
+  delete mwv_true;
+  delete mwv;
   delete vwr;
   delete mwd;
   delete parser;
@@ -62,6 +68,53 @@ void test_vwr_port(void) {
   TEST_ASSERT_FLOAT_WITHIN(0.01, 5.1, vwr->apparent_wind_speed_.get());
 }
 
+void test_mwv_apparent_non_wi_talker(void) {
+  // MWV with II talker (integrated instruments) should parse as apparent wind
+  parser->set("$IIMWV,045.0,R,12.5,N,A*0A");
+
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 45.0 * DEG_TO_RAD,
+                           mwv->apparent_wind_angle_.get());
+  // 12.5 knots * 0.514444 = 6.4306 m/s
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 6.4306, mwv->apparent_wind_speed_.get());
+  TEST_ASSERT_EQUAL_INT(1, mwv->get_rx_count());
+}
+
+void test_mwv_apparent_rejects_true_wind(void) {
+  // MWV with T (true) reference should be rejected by apparent wind parser
+  parser->set("$IIMWV,225.0,T,6.4,M,A*3F");
+
+  TEST_ASSERT_EQUAL_INT(0, mwv->get_rx_count());
+}
+
+void test_mwv_true_wind(void) {
+  // MWV with T (true) reference should be parsed by true wind parser
+  parser->set("$IIMWV,225.0,T,6.4,M,A*3F");
+
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 225.0 * DEG_TO_RAD,
+                           mwv_true->true_wind_direction_.get());
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 6.4, mwv_true->true_wind_speed_.get());
+  TEST_ASSERT_EQUAL_INT(1, mwv_true->get_rx_count());
+}
+
+void test_mwv_true_rejects_apparent_wind(void) {
+  // MWV with R (relative) reference should be rejected by true wind parser
+  parser->set("$IIMWV,045.0,R,12.5,N,A*0A");
+
+  // Apparent parser should get it, not the true wind parser
+  TEST_ASSERT_EQUAL_INT(1, mwv->get_rx_count());
+  TEST_ASSERT_EQUAL_INT(0, mwv_true->get_rx_count());
+}
+
+void test_mwv_true_wind_knots(void) {
+  // MWV true wind in knots — should convert to m/s
+  parser->set("$IIMWV,180.0,T,15.0,N,A*06");
+
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 180.0 * DEG_TO_RAD,
+                           mwv_true->true_wind_direction_.get());
+  // 15.0 knots * 0.514444 = 7.7167 m/s
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 7.7167, mwv_true->true_wind_speed_.get());
+}
+
 #ifdef ARDUINO
 void setup() {
   delay(2000);
@@ -71,6 +124,11 @@ void setup() {
   RUN_TEST(test_mwd_knots_only);
   RUN_TEST(test_vwr_starboard);
   RUN_TEST(test_vwr_port);
+  RUN_TEST(test_mwv_apparent_non_wi_talker);
+  RUN_TEST(test_mwv_apparent_rejects_true_wind);
+  RUN_TEST(test_mwv_true_wind);
+  RUN_TEST(test_mwv_true_rejects_apparent_wind);
+  RUN_TEST(test_mwv_true_wind_knots);
 
   UNITY_END();
 }
@@ -84,6 +142,11 @@ int main(int argc, char** argv) {
   RUN_TEST(test_mwd_knots_only);
   RUN_TEST(test_vwr_starboard);
   RUN_TEST(test_vwr_port);
+  RUN_TEST(test_mwv_apparent_non_wi_talker);
+  RUN_TEST(test_mwv_apparent_rejects_true_wind);
+  RUN_TEST(test_mwv_true_wind);
+  RUN_TEST(test_mwv_true_rejects_apparent_wind);
+  RUN_TEST(test_mwv_true_wind_knots);
 
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- Change MWV sentence address from `WIMWV` (fixed talker) to `..MWV` (any talker), matching the pattern used by MWD and VWR parsers
- Add `TrueWindMWVSentenceParser` for MWV sentences with `T` (true) reference, wired to `TrueWindData` alongside MWD
- Fix `parse_sentence` dispatch to continue trying other parsers when one matches by address but fails to parse fields, enabling multiple parsers to share the same sentence address

Fixes #23

## Test plan

- [x] Existing MWD and VWR tests still pass (no regression from dispatch change)
- [x] MWV with non-WI talker ID (e.g., `$IIMWV`) parses correctly
- [x] Apparent wind MWV parser rejects true wind (`T`) sentences
- [x] True wind MWV parser parses `T` reference sentences correctly
- [x] True wind MWV parser rejects apparent wind (`R`) sentences
- [x] Unit conversion (knots → m/s) works for true wind MWV
- [x] All 9 tests pass on ESP32-C3 hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)