### PR TITLE
Add Signal K metadata to ConnectGNSS numeric outputs

### DIFF
--- a/src/sensesp_nmea0183/wiring.cpp
+++ b/src/sensesp_nmea0183/wiring.cpp
@@ -68,24 +68,32 @@ void ConnectGNSS(NMEA0183Parser* nmea_input, GNSSData* location_data) {
   location_data->rtk_quality.connect_to(new SKOutputString(
       "navigation.gnss.methodQuality", "/SK Path/Fix Quality"));
   location_data->num_satellites.connect_to(new SKOutputInt(
-      "navigation.gnss.satellites", "/SK Path/Number of Satellites"));
+      "navigation.gnss.satellites", "/SK Path/Number of Satellites",
+      new SKMetadata("", "Satellites")));
   location_data->horizontal_dilution.connect_to(new SKOutputFloat(
-      "navigation.gnss.horizontalDilution", "/SK Path/Horizontal Dilution"));
+      "navigation.gnss.horizontalDilution", "/SK Path/Horizontal Dilution",
+      new SKMetadata("", "Horizontal Dilution of Precision")));
   location_data->geoidal_separation.connect_to(new SKOutputFloat(
-      "navigation.gnss.geoidalSeparation", "/SK Path/Geoidal Separation"));
+      "navigation.gnss.geoidalSeparation", "/SK Path/Geoidal Separation",
+      new SKMetadata("m", "Geoidal Separation")));
   location_data->dgps_age.connect_to(new SKOutputFloat(
-      "navigation.gnss.differentialAge", "/SK Path/Differential Age"));
+      "navigation.gnss.differentialAge", "/SK Path/Differential Age",
+      new SKMetadata("s", "Differential Age")));
   location_data->dgps_id.connect_to(
       new SKOutputFloat("navigation.gnss.differentialReference",
-                        "/SK Path/Differential Reference"));
+                        "/SK Path/Differential Reference",
+                        new SKMetadata("", "Differential Reference Station ID")));
   location_data->datetime.connect_to(
       new SKOutputTime("navigation.datetime", "/SK Path/DateTime"));
   location_data->speed.connect_to(new SKOutputFloat(
-      "navigation.speedOverGround", "/SK Path/Speed Over Ground"));
+      "navigation.speedOverGround", "/SK Path/Speed Over Ground",
+      new SKMetadata("m/s", "Speed Over Ground")));
   location_data->true_course.connect_to(new SKOutputFloat(
-      "navigation.courseOverGroundTrue", "/SK Path/True Course Over Ground"));
+      "navigation.courseOverGroundTrue", "/SK Path/True Course Over Ground",
+      new SKMetadata("rad", "Course Over Ground (True)")));
   location_data->variation.connect_to(new SKOutputFloat(
-      "navigation.magneticVariation", "/SK Path/Magnetic Variation"));
+      "navigation.magneticVariation", "/SK Path/Magnetic Variation",
+      new SKMetadata("rad", "Magnetic Variation")));
   location_data->satellites.connect_to(new SKOutput<std::vector<GNSSSatellite>>(
       "navigation.gnss.satellitesInView", "/SK Path/Satellites in View"));
 }


### PR DESCRIPTION
## Why

Every numeric `SKOutput` created by `ConnectGNSS` was constructed without metadata, so each one trips the `SKOutputNumeric` "No metadata … Numeric values should specify units" warning at boot. Eight warnings per GNSS device.

## What

Pass `SKMetadata` with SI units per the Signal K specification to the eight numeric outputs:

| Path | Units |
|---|---|
| `navigation.speedOverGround` | `m/s` |
| `navigation.courseOverGroundTrue` | `rad` |
| `navigation.magneticVariation` | `rad` |
| `navigation.gnss.geoidalSeparation` | `m` |
| `navigation.gnss.differentialAge` | `s` |
| `navigation.gnss.satellites` | — (count) |
| `navigation.gnss.horizontalDilution` | — (dimensionless) |
| `navigation.gnss.differentialReference` | — (station ID) |

The three dimensionless paths get empty units plus a display name, which still satisfies the constructor's non-null check and silences the warning. Non-numeric outputs (`position`, `methodQuality`, `datetime`, `satellitesInView`) don't warn and are unchanged.

## Verification

Builds clean. The warning is a pure `meta_ == nullptr` check in the `SKOutputNumeric` constructor; every numeric output now passes a non-null `SKMetadata`, so the branch is unreachable. Verified by construction (no on-device GNSS available to capture a clean boot log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)