### PR TITLE
fix(gsv): emit satellitesInView once per cycle; satellites from GGA only

### DIFF
--- a/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
@@ -361,7 +361,8 @@ bool GSVSentenceParser::parse_fields(const char* field_strings,
   static std::vector<GNSSSatellite> satellites;
   GNSSSatellite sentence_satellites[4];
   char signal_id = '0';
-  static int first_sentence_type = 0;  // Combination of system and signal ID
+  // (system, signal) types collected since the last cycle boundary.
+  static std::vector<int> seen_types;
   String signal = "";
   GNSSSystem system = GNSSSystem::unknown;
 
@@ -451,24 +452,31 @@ bool GSVSentenceParser::parse_fields(const char* field_strings,
 
   int sentence_type = static_cast<int>(system) * 16 + signal_id;
 
-  // If the sentence type equals to the first sentence type, we have received
-  // all GSV sentences in the cycle. Notify the observers.
+  // Each (system, signal) group appears once per cycle, introduced by its
+  // message 1. So the message 1 of a group already collected this cycle means
+  // the cycle has wrapped: emit the merged set and start a new one. Detecting
+  // the boundary by "a group repeats" rather than by a fixed first-sentence
+  // anchor keeps this correct when the receiver's signal mix varies between
+  // cycles or output starts mid-cycle.
 
-  if (sentence_type == first_sentence_type) {
-    num_satellites_.set(collected_num_satellites);
-    total_svs_in_view_.set(total_svs_in_view);
-    satellites_.set(satellites);
-    collected_num_satellites = 0;
-    total_svs_in_view = 0;
-    satellites.clear();
-  }
-
-  // Finish parsing the current sentence.
-
-  if (first_sentence_type == 0) {
-    // At the first sentence, set the first_sentence_type. This is used to
-    // determine whether we have received all GSV sentences in the cycle.
-    first_sentence_type = sentence_type;
+  if (sentence_number == 1) {
+    bool wrapped = false;
+    for (int t : seen_types) {
+      if (t == sentence_type) {
+        wrapped = true;
+        break;
+      }
+    }
+    if (wrapped) {
+      num_satellites_.set(collected_num_satellites);
+      total_svs_in_view_.set(total_svs_in_view);
+      satellites_.set(satellites);
+      collected_num_satellites = 0;
+      total_svs_in_view = 0;
+      satellites.clear();
+      seen_types.clear();
+    }
+    seen_types.push_back(sentence_type);
   }
 
   // Names and IDs below copied from this document:

--- a/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
@@ -477,6 +477,10 @@ bool GSVSentenceParser::parse_fields(const char* field_strings,
       seen_types.clear();
     }
     seen_types.push_back(sentence_type);
+    // Field 3 (SVs in view) is per (system, signal) group and repeats in
+    // every sentence of that group, so add it once per group, here at its
+    // message 1.
+    total_svs_in_view += num_satellites;
   }
 
   // Names and IDs below copied from this document:
@@ -545,9 +549,6 @@ bool GSVSentenceParser::parse_fields(const char* field_strings,
     satellites.push_back(sentence_satellites[i]);
     collected_num_satellites++;
   }
-
-  // Store the total SVs in view from field 3 (same value in all sentences)
-  total_svs_in_view = num_satellites;
 
   return true;
 };

--- a/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h
+++ b/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h
@@ -97,7 +97,9 @@ class GSVSentenceParser : public SentenceParser {
 
   /// Number of satellites with data blocks received in the GSV cycle
   ObservableValue<int> num_satellites_;
-  /// Total number of SVs in view (from GSV header field 3)
+  /// Sum of GSV field 3 (SVs in view) over the cycle's (system, signal)
+  /// groups. Counts per signal like num_satellites_: a satellite tracked on
+  /// several signals is counted once per signal.
   ObservableValue<int> total_svs_in_view_;
   ObservableValue<std::vector<GNSSSatellite>> satellites_;
   ObservableValue<GNSSSatellite> first_satellite_;

--- a/src/sensesp_nmea0183/wiring.cpp
+++ b/src/sensesp_nmea0183/wiring.cpp
@@ -52,8 +52,9 @@ void ConnectGNSS(NMEA0183Parser* nmea_input, GNSSData* location_data) {
 
   vtg_sentence_parser->true_course_.connect_to(&location_data->true_course);
 
-  gsv_sentence_parser->num_satellites_.connect_to(
-      &location_data->num_satellites);
+  // num_satellites stays sourced from GGA (satellites used in the fix); GSV's
+  // count is satellites in view, already carried by satellitesInView, and wiring
+  // both here makes navigation.gnss.satellites flip between the two meanings.
   gsv_sentence_parser->satellites_.connect_to(&location_data->satellites);
 
   gsa_sentence_parser->fix_type_.connect_to(&location_data->fix_type);

--- a/test/test_gsv/test_gsv.cpp
+++ b/test/test_gsv/test_gsv.cpp
@@ -36,6 +36,7 @@ static const int kExpectedTotal = 47;
 
 static int emit_count = 0;
 static std::vector<GNSSSatellite> last_emitted;
+static int last_total_in_view = 0;
 
 static void feed_cycle() {
   for (int i = 0; i < kCycleLen; i++) {
@@ -48,9 +49,11 @@ void setUp(void) {
   gsv = new GSVSentenceParser(parser);
   emit_count = 0;
   last_emitted.clear();
+  last_total_in_view = 0;
   gsv->satellites_.attach([]() {
     emit_count++;
     last_emitted = gsv->satellites_.get();
+    last_total_in_view = gsv->total_svs_in_view_.get();
   });
 }
 
@@ -72,6 +75,10 @@ void test_gsv_one_merged_emit_per_cycle(void) {
 
   TEST_ASSERT_EQUAL_INT(1, emit_count - emits_before);
   TEST_ASSERT_EQUAL_INT(kExpectedTotal, (int)last_emitted.size());
+
+  // total_svs_in_view sums field 3 across the cycle's groups
+  // (13+7+9+10+8); the last-group-only regression reported just 8.
+  TEST_ASSERT_EQUAL_INT(kExpectedTotal, last_total_in_view);
 
   bool gps = false, glonass = false, galileo = false, beidou = false;
   for (const auto& s : last_emitted) {

--- a/test/test_gsv/test_gsv.cpp
+++ b/test/test_gsv/test_gsv.cpp
@@ -1,0 +1,101 @@
+#include <unity.h>
+
+#include <vector>
+
+#include "sensesp_nmea0183/nmea0183.h"
+#include "sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h"
+
+using namespace sensesp;
+using namespace sensesp::nmea0183;
+
+static NMEA0183Parser* parser;
+static GSVSentenceParser* gsv;
+
+// One full GSV cycle as emitted by a UM982 (new-format: a signal ID precedes
+// the checksum). The leading GPS L1 group spans four sentences -- the case that
+// tripped the cycle-end detection. Totals: GPS L1 13, GPS L2 7, GLONASS 9,
+// BeiDou 10, Galileo 8 = 47 satellite blocks across four constellations.
+static const char* kCycle[] = {
+    "$GPGSV,4,1,13,15,24,205,43,17,45,073,39,32,06,331,25,19,48,128,40,1*62",
+    "$GPGSV,4,2,13,14,19,073,35,20,12,182,27,01,16,028,30,12,26,238,40,1*65",
+    "$GPGSV,4,3,13,22,37,074,38,13,,,41,10,18,303,35,23,08,269,29,1*5B",
+    "$GPGSV,4,4,13,24,71,243,46,1*51",
+    "$GPGSV,2,1,07,14,19,073,37,20,12,182,31,01,16,028,24,13,,,41,8*51",
+    "$GPGSV,2,2,07,10,18,303,34,23,08,269,24,24,71,243,44,8*52",
+    "$GLGSV,3,1,09,73,79,058,35,72,49,278,31,80,22,078,30,71,25,214,37,1*73",
+    "$GLGSV,3,2,09,81,17,009,28,65,22,338,27,82,37,057,34,74,45,268,35,1*71",
+    "$GLGSV,3,3,09,83,21,117,29,1*45",
+    "$GBGSV,3,1,10,36,62,256,40,08,38,054,42,13,12,024,23,28,27,049,40,1*75",
+    "$GBGSV,3,2,10,27,34,099,40,19,06,207,26,22,32,254,40,21,28,315,24,1*71",
+    "$GBGSV,3,3,10,14,14,336,37,39,13,268,32,1*70",
+    "$GAGSV,2,1,08,09,32,182,39,26,18,051,37,31,65,088,40,23,16,064,31,1*79",
+    "$GAGSV,2,2,08,03,24,314,39,13,13,000,25,16,50,223,39,05,56,255,41,1*79",
+};
+static const int kCycleLen = sizeof(kCycle) / sizeof(kCycle[0]);
+static const int kExpectedTotal = 47;
+
+static int emit_count = 0;
+static std::vector<GNSSSatellite> last_emitted;
+
+static void feed_cycle() {
+  for (int i = 0; i < kCycleLen; i++) {
+    parser->set(kCycle[i]);
+  }
+}
+
+void setUp(void) {
+  parser = new NMEA0183Parser();
+  gsv = new GSVSentenceParser(parser);
+  emit_count = 0;
+  last_emitted.clear();
+  gsv->satellites_.attach([]() {
+    emit_count++;
+    last_emitted = gsv->satellites_.get();
+  });
+}
+
+void tearDown(void) {
+  delete gsv;
+  delete parser;
+}
+
+// A multi-constellation cycle must produce exactly one satellitesInView emission
+// per cycle, carrying every satellite from every constellation. The regression
+// emitted once per sentence of the leading group, flooding the path with partial
+// fragments.
+void test_gsv_one_merged_emit_per_cycle(void) {
+  feed_cycle();  // establishes the first sentence type; no emit yet
+  feed_cycle();  // the leading sentence of this cycle emits the previous one
+
+  int emits_before = emit_count;
+  feed_cycle();  // exactly one emission, carrying the whole prior cycle
+
+  TEST_ASSERT_EQUAL_INT(1, emit_count - emits_before);
+  TEST_ASSERT_EQUAL_INT(kExpectedTotal, (int)last_emitted.size());
+
+  bool gps = false, glonass = false, galileo = false, beidou = false;
+  for (const auto& s : last_emitted) {
+    gps |= s.system == GNSSSystem::gps;
+    glonass |= s.system == GNSSSystem::glonass;
+    galileo |= s.system == GNSSSystem::galileo;
+    beidou |= s.system == GNSSSystem::beidou;
+  }
+  TEST_ASSERT_TRUE(gps && glonass && galileo && beidou);
+}
+
+#ifdef ARDUINO
+void setup() {
+  delay(2000);
+  UNITY_BEGIN();
+  RUN_TEST(test_gsv_one_merged_emit_per_cycle);
+  UNITY_END();
+}
+
+void loop() {}
+#else
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_gsv_one_merged_emit_per_cycle);
+  return UNITY_END();
+}
+#endif

--- a/test/test_gsv_midcycle/test_gsv_midcycle.cpp
+++ b/test/test_gsv_midcycle/test_gsv_midcycle.cpp
@@ -1,0 +1,106 @@
+#include <unity.h>
+
+#include <vector>
+
+#include "sensesp_nmea0183/nmea0183.h"
+#include "sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h"
+
+using namespace sensesp;
+using namespace sensesp::nmea0183;
+
+static NMEA0183Parser* parser;
+static GSVSentenceParser* gsv;
+static int emit_count = 0;
+static std::vector<GNSSSatellite> last_emitted;
+
+// An intermittent Galileo signal (signal id 7) group -- a real receiver reports
+// it only in some cycles as those satellites come and go.
+static const char* kSig7Group[] = {
+    "$GAGSV,3,1,09,09,16,182,17,26,21,036,28,31,50,080,41,33,17,088,28,7*75",
+    "$GAGSV,3,2,09,03,35,305,31,16,66,225,37,05,49,231,44,25,19,243,28,7*74",
+};
+static const int kSig7Len = sizeof(kSig7Group) / sizeof(kSig7Group[0]);
+
+// A full cycle WITHOUT that signal: GPS L1/L2, GLONASS, BeiDou, Galileo L1/L2 =
+// 46 satellite blocks across four constellations.
+static const char* kCycle[] = {
+    "$GPGSV,3,1,11,15,06,199,28,17,34,056,42,32,21,322,38,19,55,098,38,1*63",
+    "$GPGSV,3,2,11,25,10,255,27,01,10,012,21,12,46,244,37,22,20,077,21,1*62",
+    "$GPGSV,3,3,11,13,,,44,10,08,287,17,24,66,185,46,1*6C",
+    "$GPGSV,2,1,06,32,21,322,31,25,10,255,30,01,10,012,25,13,,,38,8*51",
+    "$GPGSV,2,2,06,10,08,287,30,24,66,185,47,8*65",
+    "$GLGSV,2,1,06,73,57,086,38,72,36,251,32,82,31,031,25,75,15,274,18,1*7A",
+    "$GLGSV,2,2,06,74,67,286,37,83,39,101,36,1*70",
+    "$GBGSV,3,1,10,36,78,235,45,08,34,050,40,30,27,147,39,28,19,035,23,1*7F",
+    "$GBGSV,3,2,10,27,39,079,37,42,12,344,33,22,18,241,38,21,29,296,31,1*77",
+    "$GBGSV,3,3,10,14,22,322,30,39,29,274,38,1*79",
+    "$GAGSV,2,1,08,09,16,182,26,26,21,036,34,31,50,080,41,33,17,088,33,1*76",
+    "$GAGSV,2,2,08,03,35,305,36,16,66,225,42,05,49,231,39,25,19,243,37,1*73",
+    "$GAGSV,2,1,05,31,50,080,24,03,35,305,20,16,66,225,29,05,49,231,26,2*7D",
+    "$GAGSV,2,2,05,25,19,243,21,2*4A",
+};
+static const int kCycleLen = sizeof(kCycle) / sizeof(kCycle[0]);
+static const int kCycleTotal = 46;
+
+static void feed(const char** sentences, int n) {
+  for (int i = 0; i < n; i++) {
+    parser->set(sentences[i]);
+  }
+}
+
+void setUp(void) {
+  parser = new NMEA0183Parser();
+  gsv = new GSVSentenceParser(parser);
+  emit_count = 0;
+  last_emitted.clear();
+  gsv->satellites_.attach([]() {
+    emit_count++;
+    last_emitted = gsv->satellites_.get();
+  });
+}
+
+void tearDown(void) {
+  delete gsv;
+  delete parser;
+}
+
+// Reproduces the field failure: GSV output starts mid-cycle on an intermittent
+// signal that then drops out. Anchoring the cycle on the first sentence ever
+// seen latches onto that signal and never emits again -- the satellite paths
+// freeze. Cycle detection must key on a group repeating, so emission stays
+// steady regardless of where output started or which signals are present.
+void test_gsv_recovers_from_intermittent_lead(void) {
+  feed(kSig7Group, kSig7Len);  // "boot" mid-cycle on the intermittent signal
+  for (int i = 0; i < 3; i++) {
+    feed(kCycle, kCycleLen);  // then cycles that no longer contain it
+  }
+
+  TEST_ASSERT_GREATER_OR_EQUAL_INT(2, emit_count);  // not frozen
+  TEST_ASSERT_EQUAL_INT(kCycleTotal, (int)last_emitted.size());
+
+  bool gps = false, glonass = false, galileo = false, beidou = false;
+  for (const auto& s : last_emitted) {
+    gps |= s.system == GNSSSystem::gps;
+    glonass |= s.system == GNSSSystem::glonass;
+    galileo |= s.system == GNSSSystem::galileo;
+    beidou |= s.system == GNSSSystem::beidou;
+  }
+  TEST_ASSERT_TRUE(gps && glonass && galileo && beidou);
+}
+
+#ifdef ARDUINO
+void setup() {
+  delay(2000);
+  UNITY_BEGIN();
+  RUN_TEST(test_gsv_recovers_from_intermittent_lead);
+  UNITY_END();
+}
+
+void loop() {}
+#else
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_gsv_recovers_from_intermittent_lead);
+  return UNITY_END();
+}
+#endif


### PR DESCRIPTION
## Problem

On a multi-constellation receiver (here a UM982), `navigation.gnss.satellitesInView` and `navigation.gnss.satellites` misbehave in the Signal K data browser: the satellite list flickers through partial values, and the satellite count flips between two unrelated numbers.

## Root cause

`GSVSentenceParser` decided a GSV cycle was complete when the current sentence's `(system, signal)` matched a **fixed anchor** — the type of the first GSV sentence ever seen. That anchor is fragile in two ways:

1. The anchor's own group spans several sentences (`msg 1..N`) that all share its type, so the cycle "ended" on each of them — flooding `satellitesInView` with partial fragments (one delta per sentence instead of per cycle).
2. The anchor is latched once and never adapts. If GSV output starts mid-cycle, or the receiver's signal mix shifts between cycles (e.g. a Galileo signal that comes and goes), the anchor stops recurring — the satellite paths **freeze** and the internal accumulation vector grows unbounded.

Both were observed live on a device: bursts of partial `count=4` fragments, and 25s+ windows with zero emissions.

A second, independent issue for the count: `ConnectGNSS` wired **both** GGA (satellites in use) and GSV (satellites in view) to `navigation.gnss.satellites`, so that path flipped between two meanings.

## Fix

- **Cycle detection by group repetition, no fixed anchor.** Each `(system, signal)` group is introduced by its `msg 1`. When the `msg 1` of a group already collected in the current cycle reappears, the cycle has wrapped: emit the merged set and start over. This is correct regardless of where output starts or which signals are present in a given cycle.
- **`navigation.gnss.satellites` from GGA only** in `ConnectGNSS` (satellites-in-use). The in-view count already lives in `satellitesInView`.

## Tests

- `test/test_gsv` — a clean multi-constellation cycle emits exactly once per cycle with all satellites merged.
- `test/test_gsv_midcycle` — GSV output starts mid-cycle on an intermittent signal that then drops out; asserts emission stays steady (the fixed-anchor approach froze here). Both use real captured UM982 sentences.

## Known limitation (pre-existing, out of scope)

`GSVSentenceParser::parse_fields` keeps cycle state in function-local statics, so two GSV parser instances in one app would share/corrupt state. Untouched here.