### PR TITLE
Migrate parsers to Nullable<T> and standardize parse_fields

### DIFF
--- a/docs/superpowers/plans/2026-03-23-nullable-migration.md
+++ b/docs/superpowers/plans/2026-03-23-nullable-migration.md
@@ -1,0 +1,1596 @@
+# Nullable Migration and Field Parser Standardization
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace sentinel constants with `Nullable<T>` in all NMEA 0183 sentence parsers and standardize the `parse_fields()` pattern.
+
+**Architecture:** Field parsers write `Nullable<T>::invalid()` on empty fields instead of `kInvalidFloat`/`kInvalidDouble`/`kInvalidInt`. Concrete parsers declare `Nullable<T>` locals, pass `.ptr()` to field parsers, and check `is_valid()` before emitting. Public API (`ObservableValue<T>`) unchanged.
+
+**Tech Stack:** C++ (ESP32 Arduino), SensESP framework (`Nullable<T>` from `sensesp/types/nullable.h`), PlatformIO build system, Unity test framework.
+
+**Spec:** `docs/superpowers/specs/2026-03-23-nullable-migration-design.md`
+
+---
+
+### Task 1: Update field parser signatures and invalid values
+
+**Files:**
+- Modify: `src/sensesp_nmea0183/sentence_parser/field_parsers.h`
+- Modify: `src/sensesp_nmea0183/sentence_parser/field_parsers.cpp`
+
+- [ ] **Step 1: Update field_parsers.h — remove sentinel constants, change int signatures to int32_t**
+
+Replace the sentinel constants and update `ParseInt`/`ParseTime`/`ParseDate` signatures:
+
+```cpp
+// field_parsers.h — replace lines 4-13 with:
+#include <Arduino.h>
+#include <cstdint>
+#include "sensesp/types/nullable.h"
+
+namespace sensesp::nmea0183 {
+
+using sensesp::Nullable;
+```
+
+Remove these three lines entirely:
+```cpp
+constexpr float kInvalidFloat = std::numeric_limits<float>::lowest();
+constexpr double kInvalidDouble = std::numeric_limits<double>::lowest();
+constexpr int kInvalidInt = std::numeric_limits<int>::lowest();
+```
+
+Change these signatures from `int*` to `int32_t*`:
+```cpp
+bool ParseInt(int32_t* value, const char* s, bool allow_empty = false);
+
+bool ParseTime(int32_t* hour, int32_t* minute, float* second, const char* s,
+               bool allow_empty = false);
+
+bool ParseDate(int32_t* year, int32_t* month, int32_t* day, const char* s,
+               bool allow_empty = false);
+```
+
+- [ ] **Step 2: Update field_parsers.cpp — write Nullable invalid values on empty fields**
+
+In `ParseInt` (line 21-28): change `kInvalidInt` to `Nullable<int32_t>::invalid()` and `int*` to `int32_t*`:
+```cpp
+bool ParseInt(int32_t* value, const char* s, bool allow_empty) {
+  if (s[0] == 0) {
+    *value = Nullable<int32_t>::invalid();
+    return allow_empty;
+  }
+  int32_t retval = sscanf(s, "%d", value);
+  return retval == 1;
+}
+```
+
+In `ParseFloat` (line 30-37): change `kInvalidFloat` to `Nullable<float>::invalid()`:
+```cpp
+  if (s[0] == 0) {
+    *value = Nullable<float>::invalid();
+    return allow_empty;
+  }
+```
+
+In `ParseDouble` (line 39-46): change `kInvalidDouble` to `Nullable<double>::invalid()`:
+```cpp
+  if (s[0] == 0) {
+    *value = Nullable<double>::invalid();
+    return allow_empty;
+  }
+```
+
+In `ParseLatLon` (line 48-63): change `kInvalidDouble` to `Nullable<double>::invalid()`:
+```cpp
+  if (s[0] == 0) {
+    *value = Nullable<double>::invalid();
+    return allow_empty;
+  }
+```
+
+In `ParseNS` (line 65-80): add guard against negating the invalid sentinel:
+```cpp
+bool ParseNS(double* value, const char* s, bool allow_empty) {
+  if (s[0] == 0) {
+    return allow_empty;
+  }
+  if (*value == Nullable<double>::invalid()) return true;  // no-op on invalid
+
+  switch (*s) {
+    case 'N':
+      break;
+    case 'S':
+      *value *= -1;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+```
+
+In `ParseEW(double*)` (line 82-96): add the same guard:
+```cpp
+bool ParseEW(double* value, const char* s, bool allow_empty) {
+  if (s[0] == 0) {
+    return allow_empty;
+  }
+  if (*value == Nullable<double>::invalid()) return true;  // no-op on invalid
+
+  switch (*s) {
+    case 'E':
+      break;
+    case 'W':
+      *value *= -1;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+```
+
+In `ParseEW(float*)` (line 98-112): add the same guard:
+```cpp
+bool ParseEW(float* value, const char* s, bool allow_empty) {
+  if (s[0] == 0) {
+    return allow_empty;
+  }
+  if (*value == Nullable<float>::invalid()) return true;  // no-op on invalid
+
+  switch (*s) {
+    case 'E':
+      break;
+    case 'W':
+      *value *= -1;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+```
+
+In `ParseTime` (line 145-155): change to `int32_t*` and use Nullable invalid values:
+```cpp
+bool ParseTime(int32_t* hour, int32_t* minute, float* second, const char* s,
+               bool allow_empty) {
+  if (s[0] == 0) {
+    *hour = Nullable<int32_t>::invalid();
+    *minute = Nullable<int32_t>::invalid();
+    *second = Nullable<float>::invalid();
+    return allow_empty;
+  }
+  int retval = sscanf(s, "%2d%2d%f", hour, minute, second);
+  return retval == 3;
+}
+```
+
+Note: `sscanf` with `%2d` writes to `int32_t*` safely on ESP32 where `int` == `int32_t`.
+
+In `ParseDate` (line 157-169): change to `int32_t*` and use Nullable invalid values:
+```cpp
+bool ParseDate(int32_t* year, int32_t* month, int32_t* day, const char* s,
+               bool allow_empty) {
+  if (s[0] == 0) {
+    *year = Nullable<int32_t>::invalid();
+    *month = Nullable<int32_t>::invalid();
+    *day = Nullable<int32_t>::invalid();
+    return allow_empty;
+  }
+  int retval = sscanf(s, "%2d%2d%2d", day, month, year);
+  // date expressed as C struct tm
+  *year += 100;
+  *month -= 1;
+  return retval == 3;
+}
+```
+
+- [ ] **Step 3: Build to verify field parser changes compile**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio run -e pioarduino_esp32`
+Expected: Build succeeds (parsers still use old sentinel comparisons which will now compare against different values, but this is intermediate — all parsers will be updated in subsequent tasks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/sensesp_nmea0183/sentence_parser/field_parsers.h src/sensesp_nmea0183/sentence_parser/field_parsers.cpp
+git commit -m "refactor(field-parsers): replace sentinel constants with Nullable<T>::invalid()
+
+Change ParseInt/ParseTime/ParseDate signatures from int* to int32_t*
+for Nullable<int32_t> portability. Add sentinel negation guards to
+ParseNS and ParseEW. Remove kInvalidFloat/kInvalidDouble/kInvalidInt.
+
+Closes #31 (partial)"
+```
+
+---
+
+### Task 2: Migrate navigation sentence parsers
+
+**Files:**
+- Modify: `src/sensesp_nmea0183/sentence_parser/navigation_sentence_parser.cpp`
+
+- [ ] **Step 1: Migrate HDGSentenceParser (lines 7-55)**
+
+Replace raw `float` locals with `Nullable<float>`, use `.ptr()`, replace `kInvalidFloat` checks with `is_valid()`:
+
+```cpp
+bool HDGSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> heading;
+  Nullable<float> deviation;
+  Nullable<float> variation;
+
+  if (num_fields < 6) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, heading.ptr()),
+      FLDP_OPT(Float, deviation.ptr()),
+      FLDP_OPT(EW, deviation.ptr()),
+      FLDP_OPT(Float, variation.ptr()),
+      FLDP_OPT(EW, variation.ptr()),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (heading.is_valid()) {
+    magnetic_heading_.set(heading * DEG_TO_RAD);
+  }
+  if (deviation.is_valid()) {
+    deviation_.set(deviation * DEG_TO_RAD);
+  }
+  if (variation.is_valid()) {
+    variation_.set(variation * DEG_TO_RAD);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 2: Migrate VHWSentenceParser (lines 57-119)**
+
+```cpp
+bool VHWSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> true_heading;
+  Nullable<float> magnetic_heading;
+  Nullable<float> speed_knots;
+  Nullable<float> speed_kmh;
+  char t_char;
+  char m_char;
+  char n_char;
+  char k_char;
+
+  if (num_fields < 9) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, true_heading.ptr()),
+      FLDP_OPT(Char, &t_char, 'T'),
+      FLDP_OPT(Float, magnetic_heading.ptr()),
+      FLDP_OPT(Char, &m_char, 'M'),
+      FLDP_OPT(Float, speed_knots.ptr()),
+      FLDP_OPT(Char, &n_char, 'N'),
+      FLDP_OPT(Float, speed_kmh.ptr()),
+      FLDP_OPT(Char, &k_char, 'K'),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (true_heading.is_valid()) {
+    true_heading_.set(true_heading * DEG_TO_RAD);
+  }
+  if (magnetic_heading.is_valid()) {
+    magnetic_heading_.set(magnetic_heading * DEG_TO_RAD);
+  }
+  if (speed_knots.is_valid()) {
+    water_speed_.set(speed_knots * 1852.0 / 3600.0);
+  } else if (speed_kmh.is_valid()) {
+    water_speed_.set(speed_kmh * 1000.0 / 3600.0);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 3: Migrate DPTSentenceParser (lines 121-155)**
+
+```cpp
+bool DPTSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> depth;
+  Nullable<float> offset;
+
+  if (num_fields < 2) {
+    return false;
+  }
+
+  bool ok = true;
+  ok &= FLDP_OPT(Float, depth.ptr())(field_strings + field_offsets[1]);
+  if (num_fields >= 3) {
+    ok &= FLDP_OPT(Float, offset.ptr())(field_strings + field_offsets[2]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (depth.is_valid()) {
+    depth_.set(depth);
+  }
+  if (offset.is_valid()) {
+    offset_.set(offset);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 4: Migrate DBTSentenceParser (lines 157-209)**
+
+```cpp
+bool DBTSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> depth_feet;
+  Nullable<float> depth_meters;
+  Nullable<float> depth_fathoms;
+  char f_char;
+  char m_char;
+  char F_char;
+
+  if (num_fields < 7) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, depth_feet.ptr()),
+      FLDP_OPT(Char, &f_char, 'f'),
+      FLDP_OPT(Float, depth_meters.ptr()),
+      FLDP_OPT(Char, &m_char, 'M'),
+      FLDP_OPT(Float, depth_fathoms.ptr()),
+      FLDP_OPT(Char, &F_char, 'F'),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (depth_meters.is_valid()) {
+    depth_.set(depth_meters);
+  } else if (depth_feet.is_valid()) {
+    depth_.set(depth_feet * 0.3048);
+  } else if (depth_fathoms.is_valid()) {
+    depth_.set(depth_fathoms * 1.8288);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 5: Migrate MTWSentenceParser (lines 211-244)**
+
+No `kInvalidFloat` checks — all fields are required. Only change: add Nullable include at top of file. No other changes needed for this parser.
+
+Actually, `temperature` is required (FLDP not FLDP_OPT), so no Nullable needed here. Leave as-is but the `float temperature` local is fine since `FLDP` will fail the parse on empty fields.
+
+- [ ] **Step 6: Migrate HDMSentenceParser (lines 246-281)**
+
+```cpp
+bool HDMSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> heading;
+  char m_char;
+
+  if (num_fields < 3) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, heading.ptr()),
+      FLDP_OPT(Char, &m_char, 'M'),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (heading.is_valid()) {
+    magnetic_heading_.set(heading * DEG_TO_RAD);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 7: Migrate HDTSentenceParser (lines 283-318)**
+
+Same pattern as HDM:
+
+```cpp
+bool HDTSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> heading;
+  char t_char;
+
+  if (num_fields < 3) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, heading.ptr()),
+      FLDP_OPT(Char, &t_char, 'T'),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (heading.is_valid()) {
+    true_heading_.set(heading * DEG_TO_RAD);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 8: Add Nullable include to navigation_sentence_parser.cpp**
+
+Add at the top of the file, after existing includes:
+```cpp
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
+```
+
+- [ ] **Step 9: Build to verify**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio run -e pioarduino_esp32`
+Expected: Build succeeds.
+
+- [ ] **Step 10: Run existing tests**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio test -e pioarduino_esp32 --without-uploading`
+Expected: All tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/sensesp_nmea0183/sentence_parser/navigation_sentence_parser.cpp
+git commit -m "refactor(navigation): migrate to Nullable<T> and standardize parse_fields
+
+Migrate HDG, VHW, DPT, DBT, HDM, HDT parsers. MTW unchanged (all
+fields required). Replace kInvalidFloat checks with is_valid().
+
+Closes #32 (partial)"
+```
+
+---
+
+### Task 3: Migrate wind sentence parsers
+
+**Files:**
+- Modify: `src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.cpp`
+
+- [ ] **Step 1: Migrate MWVSentenceParser (lines 7-56)**
+
+MWV uses `FLDP_OPT` for float fields but does not check validity before emitting — it always calls `set()`. This is a behavior change: with Nullable, we should guard the `set()` calls. However, `ConvertSpeedToMs` requires a valid speed value, so if `wind_speed` is invalid, we'd crash in the conversion. The existing code works because the `char` checks (`FLDP_OPT(Char, &r_value, 'R')`) fail if the reference indicator is wrong, causing early return.
+
+Keep the existing unconditional `set()` pattern for MWV/TrueWindMWV since these parsers validate via the char fields (R/T, A) and `ConvertSpeedToMs`. If any field is empty, the char parse or speed conversion will fail.
+
+However, there is a pre-existing bug: if wind angle/speed fields are empty but char fields (R/T, unit, A) are present, the empty float locals receive the invalid sentinel, and `ConvertSpeedToMs` operates on it, emitting a bogus value. Fix by adding Nullable guards:
+
+```cpp
+bool MWVSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> wind_speed;
+  Nullable<float> wind_angle;
+  char r_value;
+  char units;
+  char a_value;
+
+  if (num_fields < 6) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, wind_angle.ptr()),
+      FLDP_OPT(Char, &r_value, 'R'),
+      FLDP_OPT(Float, wind_speed.ptr()),
+      FLDP_OPT(Char, &units, 255),
+      FLDP_OPT(Char, &a_value, 'A')};
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (wind_speed.is_valid()) {
+    float speed = wind_speed;
+    if (!ConvertSpeedToMs(&speed, units)) {
+      return false;
+    }
+    apparent_wind_speed_.set(speed);
+  }
+  if (wind_angle.is_valid()) {
+    apparent_wind_angle_.set(wind_angle * DEG_TO_RAD);
+  }
+
+  return true;
+}
+```
+
+Apply the same pattern to TrueWindMWVSentenceParser (identical structure, different observables: `true_wind_speed_`, `true_wind_direction_`).
+
+- [ ] **Step 2: Migrate MWDSentenceParser (lines 108-167)**
+
+```cpp
+bool MWDSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> true_direction;
+  Nullable<float> magnetic_direction;
+  Nullable<float> speed_knots;
+  Nullable<float> speed_ms;
+  char t_char;
+  char m_char;
+  char n_char;
+  char ms_char;
+
+  if (num_fields < 9) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, true_direction.ptr()),
+      FLDP_OPT(Char, &t_char, 'T'),
+      FLDP_OPT(Float, magnetic_direction.ptr()),
+      FLDP_OPT(Char, &m_char, 'M'),
+      FLDP_OPT(Float, speed_knots.ptr()),
+      FLDP_OPT(Char, &n_char, 'N'),
+      FLDP_OPT(Float, speed_ms.ptr()),
+      FLDP_OPT(Char, &ms_char, 'M'),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (true_direction.is_valid()) {
+    true_wind_direction_.set(true_direction * DEG_TO_RAD);
+  }
+  if (speed_ms.is_valid()) {
+    true_wind_speed_.set(speed_ms);
+  } else if (speed_knots.is_valid()) {
+    true_wind_speed_.set(speed_knots * 1852.0 / 3600.0);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 3: Migrate VWRSentenceParser (lines 169-235)**
+
+```cpp
+bool VWRSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> angle;
+  char lr_char;
+  Nullable<float> speed_knots;
+  Nullable<float> speed_ms;
+  Nullable<float> speed_kmh;
+  char n_char;
+  char ms_char;
+  char k_char;
+
+  if (num_fields < 9) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, angle.ptr()),
+      FLDP_OPT(Char, &lr_char, 255),
+      FLDP_OPT(Float, speed_knots.ptr()),
+      FLDP_OPT(Char, &n_char, 'N'),
+      FLDP_OPT(Float, speed_ms.ptr()),
+      FLDP_OPT(Char, &ms_char, 'M'),
+      FLDP_OPT(Float, speed_kmh.ptr()),
+      FLDP_OPT(Char, &k_char, 'K'),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (angle.is_valid()) {
+    float signed_angle = angle * DEG_TO_RAD;
+    if (lr_char == 'L') {
+      signed_angle = -signed_angle;
+    }
+    apparent_wind_angle_.set(signed_angle);
+  }
+
+  if (speed_ms.is_valid()) {
+    apparent_wind_speed_.set(speed_ms);
+  } else if (speed_knots.is_valid()) {
+    apparent_wind_speed_.set(speed_knots * 1852.0 / 3600.0);
+  } else if (speed_kmh.is_valid()) {
+    apparent_wind_speed_.set(speed_kmh * 1000.0 / 3600.0);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 4: Add Nullable include to wind_sentence_parser.cpp**
+
+Add after existing includes:
+```cpp
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
+```
+
+- [ ] **Step 5: Build and test**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio run -e pioarduino_esp32 && pio test -e pioarduino_esp32 --without-uploading`
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.cpp
+git commit -m "refactor(wind): migrate MWD and VWR to Nullable<T>
+
+MWV and TrueWindMWV: add Nullable guards for wind angle/speed
+to fix pre-existing bug where empty float fields with present char
+fields would emit bogus values through ConvertSpeedToMs."
+```
+
+---
+
+### Task 4: Migrate weather sentence parser
+
+**Files:**
+- Modify: `src/sensesp_nmea0183/sentence_parser/weather_sentence_parser.cpp`
+
+- [ ] **Step 1: Migrate MDASentenceParser**
+
+Replace all `float` locals that use `kInvalidFloat` checks with `Nullable<float>`:
+
+```cpp
+bool MDASentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> pressure_inhg;
+  Nullable<float> pressure_bars;
+  Nullable<float> air_temp;
+  Nullable<float> water_temp;
+  Nullable<float> humidity;
+  Nullable<float> dew_point;
+  Nullable<float> wind_dir_true;
+  Nullable<float> wind_dir_mag;
+  Nullable<float> abs_humidity;
+  Nullable<float> wind_speed_kn;
+  Nullable<float> wind_speed_ms;
+  char i_char;
+  char b_char;
+  char c1_char;
+  char c2_char;
+  char c3_char;
+  char t_char;
+  char m_char;
+  char n_char;
+  char ms_char;
+
+  if (num_fields < 21) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, pressure_inhg.ptr()),
+      FLDP_OPT(Char, &i_char, 'I'),
+      FLDP_OPT(Float, pressure_bars.ptr()),
+      FLDP_OPT(Char, &b_char, 'B'),
+      FLDP_OPT(Float, air_temp.ptr()),
+      FLDP_OPT(Char, &c1_char, 'C'),
+      FLDP_OPT(Float, water_temp.ptr()),
+      FLDP_OPT(Char, &c2_char, 'C'),
+      FLDP_OPT(Float, humidity.ptr()),
+      FLDP_OPT(Float, abs_humidity.ptr()),
+      FLDP_OPT(Float, dew_point.ptr()),
+      FLDP_OPT(Char, &c3_char, 'C'),
+      FLDP_OPT(Float, wind_dir_true.ptr()),
+      FLDP_OPT(Char, &t_char, 'T'),
+      FLDP_OPT(Float, wind_dir_mag.ptr()),
+      FLDP_OPT(Char, &m_char, 'M'),
+      FLDP_OPT(Float, wind_speed_kn.ptr()),
+      FLDP_OPT(Char, &n_char, 'N'),
+      FLDP_OPT(Float, wind_speed_ms.ptr()),
+      FLDP_OPT(Char, &ms_char, 'M'),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (pressure_bars.is_valid()) {
+    barometric_pressure_.set(pressure_bars * 100000.0);
+  } else if (pressure_inhg.is_valid()) {
+    barometric_pressure_.set(pressure_inhg * 3386.389);
+  }
+
+  if (air_temp.is_valid()) {
+    air_temperature_.set(air_temp + 273.15);
+  }
+  if (water_temp.is_valid()) {
+    water_temperature_.set(water_temp + 273.15);
+  }
+  if (humidity.is_valid()) {
+    relative_humidity_.set(humidity / 100.0);
+  }
+  if (dew_point.is_valid()) {
+    dew_point_.set(dew_point + 273.15);
+  }
+  if (wind_dir_true.is_valid()) {
+    true_wind_direction_.set(wind_dir_true * DEG_TO_RAD);
+  }
+  if (wind_speed_ms.is_valid()) {
+    true_wind_speed_.set(wind_speed_ms);
+  } else if (wind_speed_kn.is_valid()) {
+    true_wind_speed_.set(wind_speed_kn * 1852.0 / 3600.0);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 2: Add Nullable include**
+
+```cpp
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio run -e pioarduino_esp32 && pio test -e pioarduino_esp32 --without-uploading`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/sensesp_nmea0183/sentence_parser/weather_sentence_parser.cpp
+git commit -m "refactor(weather): migrate MDA parser to Nullable<T>"
+```
+
+---
+
+### Task 5: Migrate GNSS sentence parsers
+
+**Files:**
+- Modify: `src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp`
+
+This is the largest file. Some parsers (SkyTraqPSTI030, SkyTraqPSTI032, QuectelPQTMTAR) use only required fields (FLDP) and don't check sentinels — they don't need Nullable. Others need careful migration.
+
+- [ ] **Step 1: Migrate GGASentenceParser (lines 57-154)**
+
+Key changes: parse lat/lon into separate Nullable locals instead of directly into Position struct. Required fields (FLDP) stay as raw `int32_t` — only optional fields (FLDP_OPT) use Nullable:
+
+```cpp
+bool GGASentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  int32_t hour, minute;
+  float second;
+  Nullable<double> latitude, longitude;
+  Nullable<float> altitude;
+  int32_t quality;
+  int32_t num_satellites;
+  Nullable<float> horizontal_dilution;
+  Nullable<float> geoidal_separation;
+  Nullable<float> dgps_age;
+  Nullable<int32_t> dgps_id;
+  char antenna_height_unit;
+  char geoidal_separation_unit;
+
+  if (num_fields < 15) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP(Time, &hour, &minute, &second),
+      FLDP_OPT(LatLon, latitude.ptr()),
+      FLDP_OPT(NS, latitude.ptr()),
+      FLDP_OPT(LatLon, longitude.ptr()),
+      FLDP_OPT(EW, longitude.ptr()),
+      FLDP(Int, &quality),
+      FLDP(Int, &num_satellites),
+      FLDP_OPT(Float, horizontal_dilution.ptr()),
+      FLDP_OPT(Float, altitude.ptr()),
+      FLDP_OPT(Char, &antenna_height_unit, 'M'),
+      FLDP_OPT(Float, geoidal_separation.ptr()),
+      FLDP_OPT(Char, &geoidal_separation_unit, 'M'),
+      FLDP_OPT(Float, dgps_age.ptr()),
+      FLDP_OPT(Int, dgps_id.ptr())};
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (latitude.is_valid() && longitude.is_valid()) {
+    Position position{latitude, longitude,
+                      altitude.is_valid() ? (double)altitude
+                                          : kPositionInvalidAltitude};
+    position_.set(position);
+  }
+  gnss_quality_.set(gnss_quality_strings[quality]);
+  quality_.set(quality);
+  num_satellites_.set(num_satellites);
+
+  if (quality != 0) {
+    if (horizontal_dilution.is_valid()) {
+      horizontal_dilution_.set(horizontal_dilution);
+    }
+    if (geoidal_separation.is_valid()) {
+      geoidal_separation_.set(geoidal_separation);
+    }
+    if (dgps_age.is_valid()) {
+      dgps_age_.set(dgps_age);
+    }
+    if (dgps_id.is_valid()) {
+      dgps_id_.set(dgps_id);
+    }
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 2: Migrate GLLSentenceParser (lines 156-202)**
+
+```cpp
+bool GLLSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<double> latitude, longitude;
+
+  if (num_fields < 5) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(LatLon, latitude.ptr()),
+      FLDP_OPT(NS, latitude.ptr()),
+      FLDP_OPT(LatLon, longitude.ptr()),
+      FLDP_OPT(EW, longitude.ptr())
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (latitude.is_valid() && longitude.is_valid()) {
+    Position position{latitude, longitude, kPositionInvalidAltitude};
+    position_.set(position);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 3: Migrate RMCSentenceParser (lines 204-289)**
+
+RMC uses `struct tm` with `int` fields. Required time/date fields stay as raw `int32_t`. Optional position/speed/course/variation use Nullable:
+
+```cpp
+bool RMCSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  int32_t hour, minute;
+  float second;
+  bool is_valid = false;
+  Nullable<double> latitude, longitude;
+  Nullable<float> speed;
+  Nullable<float> true_course;
+  Nullable<float> variation;
+  int32_t year, month, day;
+
+  if (num_fields < 12) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP(Time, &hour, &minute, &second),
+      FLDP(AV, &is_valid),
+      FLDP_OPT(LatLon, latitude.ptr()),
+      FLDP_OPT(NS, latitude.ptr()),
+      FLDP_OPT(LatLon, longitude.ptr()),
+      FLDP_OPT(EW, longitude.ptr()),
+      FLDP_OPT(Float, speed.ptr()),
+      FLDP_OPT(Float, true_course.ptr()),
+      FLDP(Date, &year, &month, &day),
+      FLDP_OPT(Float, variation.ptr()),
+      FLDP_OPT(EW, variation.ptr())
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (is_valid) {
+    if (latitude.is_valid() && longitude.is_valid()) {
+      Position position{latitude, longitude, kPositionInvalidAltitude};
+      position_.set(position);
+    }
+    struct tm time = {};
+    time.tm_year = year;
+    time.tm_mon = month;
+    time.tm_mday = day;
+    time.tm_hour = hour;
+    time.tm_min = minute;
+    time.tm_sec = (int)second;
+    time.tm_isdst = 0;
+    datetime_.set(mktime(&time));
+
+    if (speed.is_valid()) {
+      speed_.set(1852. * speed / 3600.);
+    }
+    if (true_course.is_valid()) {
+      true_course_.set(2 * PI * true_course / 360.);
+    }
+    if (variation.is_valid()) {
+      variation_.set(2 * PI * variation / 360.);
+    }
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 4: Migrate VTGSentenceParser (lines 291-347)**
+
+```cpp
+bool VTGSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  Nullable<float> true_track;
+  Nullable<float> magnetic_track;
+  Nullable<float> ground_speed;
+  char true_track_symbol;
+  char magnetic_track_symbol;
+  char ground_speed_knots_unit;
+
+  if (num_fields < 9) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, true_track.ptr()),
+      FLDP_OPT(Char, &true_track_symbol, 'T'),
+      FLDP_OPT(Float, magnetic_track.ptr()),
+      FLDP_OPT(Char, &magnetic_track_symbol, 'M'),
+      FLDP_OPT(Float, ground_speed.ptr()),
+      FLDP_OPT(Char, &ground_speed_knots_unit, 'N')
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (true_track.is_valid()) {
+    true_course_.set(2 * PI * true_track / 360.);
+  }
+  if (ground_speed.is_valid()) {
+    speed_.set(1852. * ground_speed / 3600.);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 5: Migrate GSVSentenceParser (lines 349-545)**
+
+GSV already uses `Nullable` for elevation/azimuth via `.ptr()`. Changes needed:
+- `int num_sentences`, `int sentence_number`, `int num_satellites` → `int32_t` (since ParseInt now takes `int32_t*`)
+- Static locals also change to `int32_t`
+- No other Nullable changes needed since the satellite fields already use Nullable
+
+Update the local variable declarations:
+```cpp
+  static int32_t num_sentences = 0;
+  int32_t sentence_number = 0;
+  // ...
+  int32_t num_satellites = 0;
+```
+
+And the satellite ID field:
+```cpp
+  FLDP_OPT(Int, &sentence_satellites[j].id),
+```
+Also change `GNSSSatellite.id` and `GNSSSatellite.snr` from `int` to `int32_t` in `src/sensesp_nmea0183/data/gnss_data.h` to match the `ParseInt` signature change.
+
+- [ ] **Step 6: Migrate GSASentenceParser (lines 805-850)**
+
+```cpp
+bool GSASentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  char mode;
+  int32_t fix_type;
+  Nullable<float> pdop;
+  Nullable<float> hdop;
+  Nullable<float> vdop;
+
+  if (num_fields < 18) {
+    return false;
+  }
+
+  bool ok = true;
+  ok &= FLDP_OPT(Char, &mode, 255)(field_strings + field_offsets[1]);
+  ok &= FLDP(Int, &fix_type)(field_strings + field_offsets[2]);
+  ok &= FLDP_OPT(Float, pdop.ptr())(field_strings + field_offsets[15]);
+  ok &= FLDP_OPT(Float, hdop.ptr())(field_strings + field_offsets[16]);
+  ok &= FLDP_OPT(Float, vdop.ptr())(field_strings + field_offsets[17]);
+
+  if (!ok) {
+    return false;
+  }
+
+  fix_type_.set(fix_type);
+  if (pdop.is_valid()) {
+    pdop_.set(pdop);
+  }
+  if (hdop.is_valid()) {
+    hdop_.set(hdop);
+  }
+  if (vdop.is_valid()) {
+    vdop_.set(vdop);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 7: Migrate ZDASentenceParser (lines 852-893)**
+
+ZDA uses only required fields (FLDP), so the int locals just need `int32_t`:
+
+```cpp
+bool ZDASentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  int32_t hour, minute;
+  float second;
+  int32_t day, month, year;
+
+  if (num_fields < 5) {
+    return false;
+  }
+
+  bool ok = true;
+  ok &= FLDP(Time, &hour, &minute, &second)(
+      field_strings + field_offsets[1]);
+  ok &= FLDP(Int, &day)(field_strings + field_offsets[2]);
+  ok &= FLDP(Int, &month)(field_strings + field_offsets[3]);
+  ok &= FLDP(Int, &year)(field_strings + field_offsets[4]);
+
+  if (!ok) {
+    return false;
+  }
+
+  struct tm time = {};
+  time.tm_hour = hour;
+  time.tm_min = minute;
+  time.tm_sec = (int)second;
+  time.tm_mday = day;
+  time.tm_mon = month - 1;
+  time.tm_year = year - 1900;
+  time.tm_isdst = 0;
+
+  datetime_.set(mktime(&time));
+
+  return true;
+}
+```
+
+- [ ] **Step 8: Migrate GBSSentenceParser (lines 895-935)**
+
+```cpp
+bool GBSSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  int32_t hour, minute;
+  float second;
+  Nullable<float> lat_error;
+  Nullable<float> lon_error;
+  Nullable<float> alt_error;
+
+  if (num_fields < 5) {
+    return false;
+  }
+
+  bool ok = true;
+  ok &= FLDP(Time, &hour, &minute, &second)(
+      field_strings + field_offsets[1]);
+  ok &= FLDP_OPT(Float, lat_error.ptr())(field_strings + field_offsets[2]);
+  ok &= FLDP_OPT(Float, lon_error.ptr())(field_strings + field_offsets[3]);
+  ok &= FLDP_OPT(Float, alt_error.ptr())(field_strings + field_offsets[4]);
+
+  if (!ok) {
+    return false;
+  }
+
+  if (lat_error.is_valid()) {
+    lat_error_.set(lat_error);
+  }
+  if (lon_error.is_valid()) {
+    lon_error_.set(lon_error);
+  }
+  if (alt_error.is_valid()) {
+    alt_error_.set(alt_error);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 9: Update SkyTraq/Quectel parsers for int32_t**
+
+These parsers use only required fields (FLDP) and don't check sentinels. Only change needed: `int` locals passed to `ParseInt`/`ParseTime`/`ParseDate` become `int32_t`, and `struct tm` is populated by assignment.
+
+For **SkyTraqPSTI030** (line 547): replace `struct tm time;` pattern with `int32_t` locals:
+```cpp
+  int32_t hour, minute;
+  float second;
+  // ... other locals unchanged ...
+  int32_t year, month, day;
+
+  // In the fps array, change:
+  FLDP(Time, &hour, &minute, &second),
+  // ... later:
+  FLDP(Date, &year, &month, &day),
+
+  // After parsing, construct tm:
+  struct tm time = {};
+  time.tm_hour = hour;
+  time.tm_min = minute;
+  time.tm_sec = (int)second;
+  time.tm_year = year;  // ParseDate already adds 100
+  time.tm_mon = month;  // ParseDate already subtracts 1
+  time.tm_mday = day;
+  time.tm_isdst = 0;
+```
+
+For **SkyTraqPSTI032** (line 647): same pattern — `int32_t` locals for time/date fields, copy to `tm` after parsing.
+
+For **QuectelPQTMTAR** (line 731): change `int heading_status` → `int32_t heading_status`, `int hdg_num_satellites` → `int32_t hdg_num_satellites`, and time fields to `int32_t` locals as above.
+
+- [ ] **Step 10: Add Nullable include to gnss_sentence_parser.cpp**
+
+Add after existing includes:
+```cpp
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
+```
+
+- [ ] **Step 11: Build and test**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio run -e pioarduino_esp32 && pio test -e pioarduino_esp32 --without-uploading`
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
+git commit -m "refactor(gnss): migrate to Nullable<T> and int32_t
+
+Migrate GGA, GLL, RMC, VTG, GSA, GBS parsers to Nullable<T>.
+Update GSV, ZDA, SkyTraq, Quectel for int32_t compatibility.
+Position structs constructed from validated Nullable locals."
+```
+
+---
+
+### Task 6: Migrate waypoint sentence parsers
+
+**Files:**
+- Modify: `src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.cpp`
+
+- [ ] **Step 1: Migrate RMBSentenceParser (lines 7-90)**
+
+```cpp
+bool RMBSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  bool is_valid;
+  Nullable<float> xte;
+  char steer_dir;
+  String origin_wp;
+  String dest_wp;
+  Nullable<double> dest_lat;
+  Nullable<double> dest_lon;
+  Nullable<float> range_nm;
+  Nullable<float> bearing;
+  Nullable<float> closing_velocity;
+  char arrival_status;
+
+  if (num_fields < 14) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP(AV, &is_valid),
+      FLDP_OPT(Float, xte.ptr()),
+      FLDP_OPT(Char, &steer_dir, 255),
+      FLDP_OPT(String, &origin_wp),
+      FLDP_OPT(String, &dest_wp),
+      FLDP_OPT(LatLon, dest_lat.ptr()),
+      FLDP_OPT(NS, dest_lat.ptr()),
+      FLDP_OPT(LatLon, dest_lon.ptr()),
+      FLDP_OPT(EW, dest_lon.ptr()),
+      FLDP_OPT(Float, range_nm.ptr()),
+      FLDP_OPT(Float, bearing.ptr()),
+      FLDP_OPT(Float, closing_velocity.ptr()),
+      FLDP_OPT(Char, &arrival_status, 255),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (xte.is_valid()) {
+    float signed_xte = xte * 1852.0;
+    if (steer_dir == 'L') {
+      signed_xte = -signed_xte;
+    }
+    cross_track_error_.set(signed_xte);
+  }
+  if (bearing.is_valid()) {
+    bearing_to_destination_.set(bearing * DEG_TO_RAD);
+  }
+  if (range_nm.is_valid()) {
+    range_to_destination_.set(range_nm * 1852.0);
+  }
+  if (closing_velocity.is_valid()) {
+    destination_closing_velocity_.set(closing_velocity * 1852.0 / 3600.0);
+  }
+  if (dest_wp.length() > 0) {
+    destination_waypoint_id_.set(dest_wp);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 2: Migrate APBSentenceParser (lines 92-171)**
+
+```cpp
+bool APBSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  bool status1;
+  bool status2;
+  Nullable<float> xte;
+  char steer_dir;
+  char xte_units;
+  char arrival_circle;
+  char perpendicular;
+  Nullable<float> bearing_origin_dest;
+  char bearing_od_type;
+  String dest_wp;
+  Nullable<float> bearing_pos_dest;
+  char bearing_pd_type;
+  Nullable<float> heading_to_steer;
+  char heading_type;
+
+  if (num_fields < 15) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP(AV, &status1),
+      FLDP(AV, &status2),
+      FLDP_OPT(Float, xte.ptr()),
+      FLDP_OPT(Char, &steer_dir, 255),
+      FLDP_OPT(Char, &xte_units, 'N'),
+      FLDP_OPT(Char, &arrival_circle, 255),
+      FLDP_OPT(Char, &perpendicular, 255),
+      FLDP_OPT(Float, bearing_origin_dest.ptr()),
+      FLDP_OPT(Char, &bearing_od_type, 255),
+      FLDP_OPT(String, &dest_wp),
+      FLDP_OPT(Float, bearing_pos_dest.ptr()),
+      FLDP_OPT(Char, &bearing_pd_type, 255),
+      FLDP_OPT(Float, heading_to_steer.ptr()),
+      FLDP_OPT(Char, &heading_type, 255),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (xte.is_valid()) {
+    float signed_xte = xte * 1852.0;
+    if (steer_dir == 'L') {
+      signed_xte = -signed_xte;
+    }
+    cross_track_error_.set(signed_xte);
+  }
+  if (heading_to_steer.is_valid()) {
+    heading_to_steer_.set(heading_to_steer * DEG_TO_RAD);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 3: Migrate BWCSentenceParser (lines 173-255)**
+
+BWC time field uses FLDP_OPT but the parsed time values are not emitted, so raw locals are fine:
+
+```cpp
+bool BWCSentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  int32_t hour, minute;
+  float second;
+  Nullable<double> lat;
+  Nullable<double> lon;
+  Nullable<float> bearing_true;
+  Nullable<float> bearing_mag;
+  Nullable<float> distance_nm;
+  String waypoint_id;
+  char t_char;
+  char m_char;
+  char n_char;
+
+  if (num_fields < 13) {
+    return false;
+  }
+
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Time, &hour, &minute, &second),
+      FLDP_OPT(LatLon, lat.ptr()),
+      FLDP_OPT(NS, lat.ptr()),
+      FLDP_OPT(LatLon, lon.ptr()),
+      FLDP_OPT(EW, lon.ptr()),
+      FLDP_OPT(Float, bearing_true.ptr()),
+      FLDP_OPT(Char, &t_char, 'T'),
+      FLDP_OPT(Float, bearing_mag.ptr()),
+      FLDP_OPT(Char, &m_char, 'M'),
+      FLDP_OPT(Float, distance_nm.ptr()),
+      FLDP_OPT(Char, &n_char, 'N'),
+      FLDP_OPT(String, &waypoint_id),
+  };
+
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+    ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+
+  if (!ok) {
+    return false;
+  }
+
+  if (bearing_true.is_valid()) {
+    bearing_true_.set(bearing_true * DEG_TO_RAD);
+  }
+  if (bearing_mag.is_valid()) {
+    bearing_magnetic_.set(bearing_mag * DEG_TO_RAD);
+  }
+  if (distance_nm.is_valid()) {
+    distance_.set(distance_nm * 1852.0);
+  }
+  if (waypoint_id.length() > 0) {
+    waypoint_id_.set(waypoint_id);
+  }
+  if (lat.is_valid() && lon.is_valid()) {
+    Position pos{lat, lon, kPositionInvalidAltitude};
+    waypoint_position_.set(pos);
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 4: Migrate WPLSentenceParser (lines 257-302)**
+
+WPL uses only required fields (FLDP). Only change: use Nullable for lat/lon in case we want consistency, but since these are required fields that fail the parse on empty, raw `double` is fine. Only change needed: nothing — WPL doesn't check sentinels. Leave as-is but change `double lat, lon` to be consistent... Actually, since `ParseLatLon` now writes `Nullable<double>::invalid()` on empty (and FLDP fails on empty), the raw doubles never see the invalid value in practice. Leave WPL unchanged.
+
+Wait — `ParseLatLon` still takes `double*`, and a raw `double lat` works fine. No change needed.
+
+- [ ] **Step 5: Migrate RTESentenceParser (lines 304-354)**
+
+RTE uses only required fields for the header (FLDP). Change `int` locals to `int32_t`:
+
+```cpp
+bool RTESentenceParser::parse_fields(const char* field_strings,
+                                     const int field_offsets[],
+                                     int num_fields) {
+  int32_t num_sentences;
+  int32_t sentence_number;
+  char route_type;
+  String route_id;
+
+  if (num_fields < 5) {
+    return false;
+  }
+
+  bool ok = true;
+  ok &= FLDP(Int, &num_sentences)(field_strings + field_offsets[1]);
+  ok &= FLDP(Int, &sentence_number)(field_strings + field_offsets[2]);
+  ok &= FLDP(Char, &route_type, 255)(field_strings + field_offsets[3]);
+  ok &= FLDP(String, &route_id)(field_strings + field_offsets[4]);
+
+  if (!ok) {
+    return false;
+  }
+
+  if (sentence_number == 1) {
+    accumulated_waypoints_.clear();
+    total_sentences_ = num_sentences;
+  }
+
+  for (int i = 5; i < num_fields; i++) {
+    String wp_id;
+    if (FLDP_OPT(String, &wp_id)(field_strings + field_offsets[i])) {
+      if (wp_id.length() > 0) {
+        accumulated_waypoints_.push_back(wp_id);
+      }
+    }
+  }
+
+  if (sentence_number == total_sentences_) {
+    route_id_.set(route_id);
+    waypoints_.set(accumulated_waypoints_);
+  }
+
+  return true;
+}
+```
+
+Also change `total_sentences_` member in `waypoint_sentence_parser.h` from `int` to `int32_t`.
+
+- [ ] **Step 6: Add Nullable include to waypoint_sentence_parser.cpp**
+
+```cpp
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
+```
+
+- [ ] **Step 7: Build and test**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio run -e pioarduino_esp32 && pio test -e pioarduino_esp32 --without-uploading`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.cpp src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.h
+git commit -m "refactor(waypoint): migrate RMB, APB, BWC to Nullable<T>
+
+WPL and RTE use only required fields; updated for int32_t only."
+```
+
+---
+
+### Task 7: Update tests and final cleanup
+
+**Files:**
+- Modify: all test files that reference `kInvalidFloat`, `kInvalidDouble`, or `kInvalidInt`
+
+- [ ] **Step 1: Search for remaining sentinel references**
+
+Run: `grep -r "kInvalidFloat\|kInvalidDouble\|kInvalidInt" /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183/`
+Expected: Only hits should be in test files or possibly in the data headers. Fix any remaining references.
+
+- [ ] **Step 2: Update test files**
+
+For any test that directly references `kInvalidFloat`/`kInvalidDouble`/`kInvalidInt`, replace with `Nullable<T>::invalid()` or restructure the assertion. Most tests check `ObservableValue::get()` or `rx_count` — those should be unaffected.
+
+- [ ] **Step 3: Full build across all environments**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio run -e pioarduino_esp32 && pio run -e arduino_esp32`
+Expected: Both build successfully.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cd /Users/mairas/w/hatlabs/esp32/SensESP/NMEA0183 && pio test -e pioarduino_esp32 --without-uploading`
+Expected: All 9 test suites pass.
+
+- [ ] **Step 5: Commit any remaining changes**
+
+```bash
+git add -A
+git commit -m "test: update tests for Nullable<T> migration
+
+Remove references to removed sentinel constants.
+
+Closes #31, closes #32"
+```

--- a/docs/superpowers/specs/2026-03-23-nullable-migration-design.md
+++ b/docs/superpowers/specs/2026-03-23-nullable-migration-design.md
@@ -1,0 +1,181 @@
+# Nullable Migration and Field Parser Standardization
+
+**Issues:** [#31](https://github.com/SensESP/NMEA0183/issues/31), [#32](https://github.com/SensESP/NMEA0183/issues/32)
+**Date:** 2026-03-23
+
+## Problem
+
+The NMEA0183 library uses sentinel constants (`kInvalidFloat`, `kInvalidDouble`, `kInvalidInt`) to represent unparsed/empty fields. This pattern is fragile — callers must remember to check against magic constants — and inconsistent with the `Nullable<T>` type already used in `GNSSSatellite`. Concrete parser implementations also vary in structure: some use a lambda array + loop, others use inline calls, making the codebase harder to extend.
+
+## Decision: Approach B — Nullable locals, keep parser signatures
+
+### Why not the alternatives
+
+- **Approach A (Nullable return types):** Changes every field parser signature for no external benefit, since the public API (`ObservableValue<float>`) stays unchanged.
+- **Approach C (Wrapper at call sites only):** Sentinels still exist in field parsers, two validity systems coexist. Minimal readability improvement.
+- **`std::optional<T>`:** C++17 not universally supported across all CI/build environments. `Nullable<T>` can be mechanically migrated to `std::optional` later.
+
+## Design
+
+### Constraint
+
+The public API does not change. `ObservableValue<float>`, `ObservableValue<int>`, etc. remain as-is. `Nullable<T>` is internal to the parser layer.
+
+### 1. Field parser changes
+
+`ParseFloat`, `ParseInt`, `ParseDouble`, `ParseLatLon`, `ParseTime`, `ParseDate`, etc. keep their current pointer-based signatures. The change: on empty fields, they write `Nullable<T>::invalid()` instead of `kInvalidFloat`/`kInvalidInt`/`kInvalidDouble`.
+
+The sentinel constants `kInvalidFloat`, `kInvalidDouble`, `kInvalidInt` are removed from `field_parsers.h`. This is a breaking change for any downstream code that references these constants directly. This is intentional — downstream code should also migrate to `Nullable<T>` and `is_valid()`.
+
+**Sentinel value mismatch:** The old sentinels (`numeric_limits<T>::lowest()`) differ numerically from `Nullable<T>::invalid()` (`-1e9` for float/double, `0x7fffffff` for int32). This is safe because all validity checks are migrated to `is_valid()` simultaneously — no code path will compare raw values against the old constants after migration.
+
+**Portability:** Use `Nullable<int32_t>` (not `Nullable<int>`) for integer locals. `Nullable<int>::invalid_value_` is only defined for ESP Arduino v3+, but `Nullable<int32_t>` is unconditionally defined. To make this self-consistent, change `ParseInt`, `ParseTime`, and `ParseDate` signatures from `int*` to `int32_t*`. This is the one signature change in the field parser layer — necessary to avoid type mismatch between `Nullable<int32_t>::ptr()` (returns `int32_t*`) and the parser parameter types.
+
+**Includes:** `field_parsers.h` must `#include "sensesp/types/nullable.h"` and use `sensesp::Nullable<T>::invalid()` to obtain the invalid sentinel values.
+
+**Default construction:** `Nullable<T>` default-constructs to value 0 with `is_valid() == true`. This is safe because the canonical pattern's parse loop covers all declared Nullable locals — every one gets written by a field parser. The `if (!ok) return false` guard catches parse failures before step 4 can emit stale defaults.
+
+### 2. Concrete parser standardization
+
+Every `parse_fields()` implementation follows a canonical pattern:
+
+```cpp
+bool ExampleSentenceParser::parse_fields(const char* field_strings,
+                                          const int* field_offsets,
+                                          int num_fields) {
+  // 1. Declare Nullable locals
+  Nullable<float> wind_angle;
+  Nullable<float> wind_speed;
+
+  // 2. Lambda array with FLDP/FLDP_OPT macros
+  std::function<bool(const char*)> fps[] = {
+      FLDP_OPT(Float, wind_angle.ptr()),
+      FLDP_OPT(Float, wind_speed.ptr()),
+  };
+
+  // 3. Loop
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
+      ok &= fps[i - 1](field_strings + field_offsets[i]);
+  }
+  if (!ok) return false;
+
+  // 4. Emit valid values
+  if (wind_angle.is_valid()) {
+      wind_angle_.set(wind_angle * DEG_TO_RAD);
+  }
+  if (wind_speed.is_valid()) {
+      wind_speed_.set(wind_speed);
+  }
+
+  return true;
+}
+```
+
+Key conventions:
+- Nullable locals declared at top
+- Lambda array with `FLDP`/`FLDP_OPT` macros, passed `.ptr()` pointers
+- Single loop over field array
+- Validity checks via `is_valid()` before emitting to `ObservableValue`
+- Fallback logic (e.g., prefer m/s over knots in MWD/MDA) stays in step 4
+
+### Special cases
+
+#### Paired fields: LatLon + NS/EW
+
+`ParseNS` and `ParseEW` mutate an existing value (multiply by -1 for S/W). Both the coordinate and its direction modifier must share the same `Nullable` variable:
+
+```cpp
+Nullable<double> latitude;
+// Both parsers operate on the same Nullable via .ptr()
+FLDP_OPT(LatLon, latitude.ptr()),
+FLDP_OPT(NS, latitude.ptr()),
+```
+
+Do NOT create separate Nullable locals for the direction field. The same pattern applies to variation/deviation + EW in HDG.
+
+**Sentinel negation hazard:** If the latitude field is empty (written as `Nullable<double>::invalid()` = `-1e9`) but NS contains `S`, `ParseNS` would negate the value to `+1e9`, which passes `is_valid()` — a silent data corruption. Fix: add a guard in `ParseNS` and `ParseEW` to no-op when the current value equals the Nullable invalid sentinel. This check goes inside the field parser functions themselves:
+
+```cpp
+bool ParseNS(double* value, const char* s, bool allow_empty) {
+    if (s[0] == 0) return allow_empty;
+    if (*value == Nullable<double>::invalid()) return true;  // no-op on invalid
+    if (s[0] == 'S') *value *= -1;
+    return true;
+}
+```
+
+#### Multi-pointer fields: ParseTime / ParseDate
+
+`ParseTime` writes through 3 pointers (hour, minute, second). `ParseDate` writes through 3 pointers (year, month, day). Each output gets its own Nullable local:
+
+```cpp
+Nullable<int32_t> hour, minute;
+Nullable<float> second;
+// Macro receives all three .ptr() arguments
+FLDP(Time, hour.ptr(), minute.ptr(), second.ptr()),
+```
+
+When the time field is empty, `ParseTime` writes the Nullable invalid value to all three outputs. All become `!is_valid()`.
+
+#### Position struct interaction
+
+`Position` is a SensESP core type with raw `double` fields — not Nullable. Parse into separate Nullable locals, then construct Position only when valid:
+
+```cpp
+Nullable<double> latitude, longitude;
+Nullable<float> altitude;
+// ... parse fields ...
+if (latitude.is_valid() && longitude.is_valid()) {
+    Position position{latitude, longitude,
+                      altitude.is_valid() ? (double)altitude : kPositionInvalidAltitude};
+    position_.set(position);
+}
+```
+
+`kPositionInvalidAltitude` is a SensESP core constant — it stays as-is since it belongs to the Position type, not to this library.
+
+#### char fields: keep raw
+
+`ParseChar` has different semantics (checks against `expected` character). `Nullable<char>::invalid()` is `0xff`, which doesn't align with `ParseChar`'s empty-field behavior. Keep `char` locals as raw `char` — they are typically required fields validated by the `expected` parameter, not optional values needing Nullable.
+
+#### Variable-length sentences: DPT, RTE
+
+`DPTSentenceParser` has conditional field parsing based on `num_fields`. It follows the canonical pattern but with a truncated lambda array or conditional tail:
+
+```cpp
+// Parse required fields via array
+// Then conditionally parse trailing optional fields
+if (num_fields >= 3) {
+    ok &= FLDP_OPT(Float, offset.ptr())(field_strings + field_offsets[2]);
+}
+```
+
+`RTESentenceParser` keeps structural differences for its multi-sentence accumulation and variable-length waypoint list, but uses `Nullable` + `is_valid()`.
+
+### 3. Macro changes
+
+`FLDP` and `FLDP_OPT` macros are unchanged. `.ptr()` returns a raw pointer, so macros don't need to know about `Nullable`.
+
+### 4. Test changes
+
+- Remove references to `kInvalidFloat`, `kInvalidDouble`, `kInvalidInt`
+- Assertion patterns remain largely the same — tests check `ObservableValue::get()` (public API) and `rx_count`, not internal Nullable state
+
+## Scope boundaries
+
+This spec covers issues #31 and #32 only. The following remain separate:
+- **#33** (RTE multi-sentence timeout) — follow-up after this refactor
+- **#34** (ProprietarySentenceParser base class) — independent work
+- **#35** (Architecture documentation) — written after patterns settle
+
+## Files affected
+
+- `src/sensesp_nmea0183/sentence_parser/field_parsers.h` — remove sentinel constants, add Nullable include
+- `src/sensesp_nmea0183/sentence_parser/field_parsers.cpp` — write `Nullable<T>::invalid()` on empty fields
+- `src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp` — standardize pattern, use Nullable
+- `src/sensesp_nmea0183/sentence_parser/navigation_sentence_parser.cpp` — standardize pattern, use Nullable
+- `src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.cpp` — standardize pattern, use Nullable
+- `src/sensesp_nmea0183/sentence_parser/weather_sentence_parser.cpp` — standardize pattern, use Nullable
+- `src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.cpp` — standardize pattern, use Nullable
+- `test/` — update sentinel references

--- a/src/sensesp_nmea0183/data/gnss_data.h
+++ b/src/sensesp_nmea0183/data/gnss_data.h
@@ -1,6 +1,8 @@
 #ifndef SENESP_NMEA0183_GNSS_DATA_H
 #define SENESP_NMEA0183_GNSS_DATA_H
 
+#include <cstdint>
+
 #include "sensesp/signalk/signalk_output.h"
 #include "sensesp/system/observablevalue.h"
 #include "sensesp/types/nullable.h"
@@ -27,10 +29,10 @@ enum class GNSSSystem {
  */
 struct GNSSSatellite {
   GNSSSystem system;
-  int id;
+  int32_t id;
   sensesp::Nullable<float> elevation;
   sensesp::Nullable<float> azimuth;
-  int snr;
+  int32_t snr;
   String signal;
 };
 

--- a/src/sensesp_nmea0183/sentence_parser/field_parsers.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/field_parsers.cpp
@@ -6,8 +6,11 @@
 #include <ctime>
 
 #include "sensesp.h"
+#include "sensesp/types/nullable.h"
 
 namespace sensesp::nmea0183 {
+
+using sensesp::Nullable;
 
 bool ParseString(String* value, const char* s, bool allow_empty) {
   if (s[0] == 0) {
@@ -18,18 +21,18 @@ bool ParseString(String* value, const char* s, bool allow_empty) {
   return true;
 }
 
-bool ParseInt(int* value, const char* s, bool allow_empty) {
+bool ParseInt(int32_t* value, const char* s, bool allow_empty) {
   if (s[0] == 0) {
-    *value = kInvalidInt;
+    *value = Nullable<int32_t>::invalid();
     return allow_empty;
   }
-  int retval = sscanf(s, "%d", value);
+  int retval = sscanf(s, "%" SCNd32, value);
   return retval == 1;
 }
 
 bool ParseFloat(float* value, const char* s, bool allow_empty) {
   if (s[0] == 0) {
-    *value = kInvalidFloat;
+    *value = Nullable<float>::invalid();
     return allow_empty;
   }
   int retval = sscanf(s, "%f", value);
@@ -38,7 +41,7 @@ bool ParseFloat(float* value, const char* s, bool allow_empty) {
 
 bool ParseDouble(double* value, const char* s, bool allow_empty) {
   if (s[0] == 0) {
-    *value = kInvalidDouble;
+    *value = Nullable<double>::invalid();
     return allow_empty;
   }
   int retval = sscanf(s, "%lf", value);
@@ -48,7 +51,7 @@ bool ParseDouble(double* value, const char* s, bool allow_empty) {
 bool ParseLatLon(double* value, const char* s, bool allow_empty) {
   double degmin;
   if (s[0] == 0) {
-    *value = kInvalidDouble;
+    *value = Nullable<double>::invalid();
     return allow_empty;
   }
   int retval = sscanf(s, "%lf", &degmin);
@@ -66,6 +69,7 @@ bool ParseNS(double* value, const char* s, bool allow_empty) {
   if (s[0] == 0) {
     return allow_empty;
   }
+  if (*value == Nullable<double>::invalid()) return true;
 
   switch (*s) {
     case 'N':
@@ -83,6 +87,8 @@ bool ParseEW(double* value, const char* s, bool allow_empty) {
   if (s[0] == 0) {
     return allow_empty;
   }
+  if (*value == Nullable<double>::invalid()) return true;
+
   switch (*s) {
     case 'E':
       break;
@@ -99,6 +105,8 @@ bool ParseEW(float* value, const char* s, bool allow_empty) {
   if (s[0] == 0) {
     return allow_empty;
   }
+  if (*value == Nullable<float>::invalid()) return true;
+
   switch (*s) {
     case 'E':
       break;
@@ -142,26 +150,26 @@ bool ParseAV(bool* is_valid, const char* s) {
   return true;
 }
 
-bool ParseTime(int* hour, int* minute, float* second, const char* s,
+bool ParseTime(int32_t* hour, int32_t* minute, float* second, const char* s,
                bool allow_empty) {
   if (s[0] == 0) {
-    *hour = kInvalidInt;
-    *minute = kInvalidInt;
-    *second = kInvalidFloat;
+    *hour = Nullable<int32_t>::invalid();
+    *minute = Nullable<int32_t>::invalid();
+    *second = Nullable<float>::invalid();
     return allow_empty;
   }
-  int retval = sscanf(s, "%2d%2d%f", hour, minute, second);
+  int retval = sscanf(s, "%2" SCNd32 "%2" SCNd32 "%f", hour, minute, second);
   return retval == 3;
 }
 
-bool ParseDate(int* year, int* month, int* day, const char* s, bool allow_empty) {
+bool ParseDate(int32_t* year, int32_t* month, int32_t* day, const char* s, bool allow_empty) {
   if (s[0] == 0) {
-    *year = kInvalidInt;
-    *month = kInvalidInt;
-    *day = kInvalidInt;
+    *year = Nullable<int32_t>::invalid();
+    *month = Nullable<int32_t>::invalid();
+    *day = Nullable<int32_t>::invalid();
     return allow_empty;
   }
-  int retval = sscanf(s, "%2d%2d%2d", day, month, year);
+  int retval = sscanf(s, "%2" SCNd32 "%2" SCNd32 "%2" SCNd32, day, month, year);
   // date expressed as C struct tm
   *year += 100;
   *month -= 1;

--- a/src/sensesp_nmea0183/sentence_parser/field_parsers.h
+++ b/src/sensesp_nmea0183/sentence_parser/field_parsers.h
@@ -3,17 +3,16 @@
 
 #include <Arduino.h>
 
-#include <limits>
+#include <cstdint>
+
+#include "sensesp/types/nullable.h"
 
 namespace sensesp::nmea0183 {
 
-// magic values for invalid data
-constexpr float kInvalidFloat = std::numeric_limits<float>::lowest();
-constexpr double kInvalidDouble = std::numeric_limits<double>::lowest();
-constexpr int kInvalidInt = std::numeric_limits<int>::lowest();
+using sensesp::Nullable;
 
 bool ParseString(String* value, const char* s, bool allow_empty = false);
-bool ParseInt(int* value, const char* s, bool allow_empty = false);
+bool ParseInt(int32_t* value, const char* s, bool allow_empty = false);
 bool ParseFloat(float* value, const char* s, bool allow_empty = false);
 bool ParseDouble(double* value, const char* s, bool allow_empty = false);
 bool ParseLatLon(double* value, const char* s, bool allow_empty = false);
@@ -24,10 +23,10 @@ bool ParseChar(char* value, const char expected, const char* s,
                bool allow_empty = false);
 bool ParseAV(bool* is_valid, const char* s);
 
-bool ParseTime(int* hour, int* minute, float* second, const char* s,
+bool ParseTime(int32_t* hour, int32_t* minute, float* second, const char* s,
                bool allow_empty = false);
 
-bool ParseDate(int* year, int* month, int* day, const char* s,
+bool ParseDate(int32_t* year, int32_t* month, int32_t* day, const char* s,
                bool allow_empty = false);
 
 bool ParseEmpty(const char* s);

--- a/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "Arduino.h"
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
 
 namespace sensesp::nmea0183 {
 
@@ -59,16 +61,18 @@ bool GGASentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  int hour;
-  int minute;
+  int32_t hour;
+  int32_t minute;
   float second;
-  Position position;
-  int quality;
-  int num_satellites;
-  float horizontal_dilution;
-  float geoidal_separation;
-  float dgps_age;
-  int dgps_id;
+  Nullable<double> latitude;
+  Nullable<double> longitude;
+  Nullable<float> altitude;
+  int32_t quality;
+  int32_t num_satellites;
+  Nullable<float> horizontal_dilution;
+  Nullable<float> geoidal_separation;
+  Nullable<float> dgps_age;
+  Nullable<int32_t> dgps_id;
   char antenna_height_unit;
   char geoidal_separation_unit;
 
@@ -87,32 +91,32 @@ bool GGASentenceParser::parse_fields(const char* field_strings,
       // 1    = UTC of Position
       FLDP(Time, &hour, &minute, &second),
       // 2    = Latitude (empty when no fix)
-      FLDP_OPT(LatLon, &position.latitude),
+      FLDP_OPT(LatLon, latitude.ptr()),
       // 3    = N or S
-      FLDP_OPT(NS, &position.latitude),
+      FLDP_OPT(NS, latitude.ptr()),
       // 4    = Longitude (empty when no fix)
-      FLDP_OPT(LatLon, &position.longitude),
+      FLDP_OPT(LatLon, longitude.ptr()),
       // 5    = E or W
-      FLDP_OPT(EW, &position.longitude),
+      FLDP_OPT(EW, longitude.ptr()),
       // 6    = GPS quality indicator (0=invalid; 1=GPS fix; 2=Diff. GPS fix)
       FLDP(Int, &quality),
       // 7    = Number of satellites in use [not those in view]
       FLDP(Int, &num_satellites),
       // 8    = Horizontal dilution of position
-      FLDP_OPT(Float, &horizontal_dilution),
+      FLDP_OPT(Float, horizontal_dilution.ptr()),
       // 9    = Antenna altitude above/below mean sea level (geoid)
-      FLDP_OPT(Float, &position.altitude),
+      FLDP_OPT(Float, altitude.ptr()),
       // 10   = Meters  (Antenna height unit)
       FLDP_OPT(Char, &antenna_height_unit, 'M'),
       // 11   = Geoidal separation (Diff. between WGS-84 earth ellipsoid and
       //        mean sea level.  -=geoid is below WGS-84 ellipsoid)
-      FLDP_OPT(Float, &geoidal_separation),
+      FLDP_OPT(Float, geoidal_separation.ptr()),
       // 12   = Meters  (Units of geoidal separation)
       FLDP_OPT(Char, &geoidal_separation_unit, 'M'),
       // 13   = Age in seconds since last update from diff. reference station
-      FLDP_OPT(Float, &dgps_age),
+      FLDP_OPT(Float, dgps_age.ptr()),
       // 14   = Diff. reference station ID#
-      FLDP_OPT(Int, &dgps_id)};
+      FLDP_OPT(Int, dgps_id.ptr())};
 
   for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
     ok &= fps[i - 1](field_strings + field_offsets[i]);
@@ -124,28 +128,30 @@ bool GGASentenceParser::parse_fields(const char* field_strings,
 
   // notify relevant observers
 
-  if (position.latitude != kInvalidDouble &&
-      position.longitude != kInvalidDouble) {
+  if (latitude.is_valid() && longitude.is_valid()) {
+    Position position;
+    position.latitude = latitude;
+    position.longitude = longitude;
+    position.altitude =
+        altitude.is_valid() ? (float)altitude : kPositionInvalidAltitude;
     position_.set(position);
   }
-  if (quality != kInvalidInt) {
-    gnss_quality_.set(gnss_quality_strings[quality]);
-    quality_.set(quality);
-  }
+  gnss_quality_.set(gnss_quality_strings[quality]);
+  quality_.set(quality);
 
   num_satellites_.set(num_satellites);
   // remaining fields are relevant only if quality is not invalid (0)
   if (quality != 0) {
-    if (horizontal_dilution != kInvalidFloat) {
+    if (horizontal_dilution.is_valid()) {
       horizontal_dilution_.set(horizontal_dilution);
     }
-    if (geoidal_separation != kInvalidFloat) {
+    if (geoidal_separation.is_valid()) {
       geoidal_separation_.set(geoidal_separation);
     }
-    if (dgps_age != kInvalidFloat) {
+    if (dgps_age.is_valid()) {
       dgps_age_.set(dgps_age);
     }
-    if (dgps_id != kInvalidInt) {
+    if (dgps_id.is_valid()) {
       dgps_id_.set(dgps_id);
     }
   }
@@ -158,7 +164,8 @@ bool GLLSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  Position position{kInvalidDouble, kInvalidDouble, kPositionInvalidAltitude};
+  Nullable<double> latitude;
+  Nullable<double> longitude;
 
   // eg.  $GPGLL,5133.81   ,N,00042.25   ,W              *75
   // eg2. $GNGLL,4916.45   ,N,12311.12   ,W,225444   ,A
@@ -171,13 +178,13 @@ bool GLLSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1    5133.81   Current latitude
-      FLDP_OPT(LatLon, &position.latitude),
+      FLDP_OPT(LatLon, latitude.ptr()),
       // 2    N         North/South
-      FLDP_OPT(NS, &position.latitude),
+      FLDP_OPT(NS, latitude.ptr()),
       // 3    00042.25  Current longitude
-      FLDP_OPT(LatLon, &position.longitude),
+      FLDP_OPT(LatLon, longitude.ptr()),
       // 4    W         East/West
-      FLDP_OPT(EW, &position.longitude)
+      FLDP_OPT(EW, longitude.ptr())
       // ignore the UTC time of the fix and the status of the fix for now
   };
 
@@ -189,12 +196,13 @@ bool GLLSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  position.altitude = kPositionInvalidAltitude;
-
   // notify relevant observers
 
-  if (position.latitude != kInvalidDouble &&
-      position.longitude != kInvalidDouble) {
+  if (latitude.is_valid() && longitude.is_valid()) {
+    Position position;
+    position.latitude = latitude;
+    position.longitude = longitude;
+    position.altitude = kPositionInvalidAltitude;
     position_.set(position);
   }
 
@@ -206,13 +214,18 @@ bool RMCSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  struct tm time;
+  int32_t hour;
+  int32_t minute;
   float second;
   bool is_valid = false;
-  Position position;
-  float speed;
-  float true_course;
-  float variation;
+  Nullable<double> latitude;
+  Nullable<double> longitude;
+  int32_t year;
+  int32_t month;
+  int32_t day;
+  Nullable<float> speed;
+  Nullable<float> true_course;
+  Nullable<float> variation;
 
   // clang-format off
   // eg.  $GPRMC,220516,   A,5133.82,   N,00042.24,   W,173.8,231.8,130694,004.2,W  *70
@@ -226,27 +239,27 @@ bool RMCSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   220516     Time Stamp
-      FLDP(Time, &time.tm_hour, &time.tm_min, &second),
+      FLDP(Time, &hour, &minute, &second),
       // 2   A          validity - A-ok, V-invalid
       FLDP(AV, &is_valid),
       // 3   5133.82    current Latitude (empty when V)
-      FLDP_OPT(LatLon, &position.latitude),
+      FLDP_OPT(LatLon, latitude.ptr()),
       // 4   N          North/South
-      FLDP_OPT(NS, &position.latitude),
+      FLDP_OPT(NS, latitude.ptr()),
       // 5   00042.24   current Longitude (empty when V)
-      FLDP_OPT(LatLon, &position.longitude),
+      FLDP_OPT(LatLon, longitude.ptr()),
       // 6   W          East/West
-      FLDP_OPT(EW, &position.longitude),
+      FLDP_OPT(EW, longitude.ptr()),
       // 7   173.8      Speed in knots (empty when stationary)
-      FLDP_OPT(Float, &speed),
+      FLDP_OPT(Float, speed.ptr()),
       // 8   231.8      True course (empty when stationary)
-      FLDP_OPT(Float, &true_course),
+      FLDP_OPT(Float, true_course.ptr()),
       // 9   130694     Date Stamp
-      FLDP(Date, &time.tm_year, &time.tm_mon, &time.tm_mday),
+      FLDP(Date, &year, &month, &day),
       // 10  004.2      Variation (empty on some receivers)
-      FLDP_OPT(Float, &variation),
+      FLDP_OPT(Float, variation.ptr()),
       // 11  W          East/West
-      FLDP_OPT(EW, &variation)
+      FLDP_OPT(EW, variation.ptr())
 
       // Positioning system mode indicator might be available as field 12, but
       // let's ignore it for now.
@@ -260,28 +273,34 @@ bool RMCSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  position.altitude = kPositionInvalidAltitude;
+  struct tm time = {};
+  time.tm_hour = hour;
+  time.tm_min = minute;
   time.tm_sec = (int)second;
+  time.tm_year = year;   // ParseDate already adds 100
+  time.tm_mon = month;   // ParseDate already subtracts 1
+  time.tm_mday = day;
   time.tm_isdst = 0;
 
   // notify relevant observers
 
   if (is_valid) {
-    if (position.latitude != kInvalidDouble &&
-        position.longitude != kInvalidDouble) {
+    if (latitude.is_valid() && longitude.is_valid()) {
+      Position position;
+      position.latitude = latitude;
+      position.longitude = longitude;
+      position.altitude = kPositionInvalidAltitude;
       position_.set(position);
     }
-    if (time.tm_year != kInvalidInt && time.tm_hour != kInvalidInt) {
-      datetime_.set(mktime(&time));
+    datetime_.set(mktime(&time));
+    if (speed.is_valid()) {
+      speed_.set(1852. * (float)speed / 3600.);
     }
-    if (speed != kInvalidFloat) {
-      speed_.set(1852. * speed / 3600.);
+    if (true_course.is_valid()) {
+      true_course_.set(2 * PI * (float)true_course / 360.);
     }
-    if (true_course != kInvalidFloat) {
-      true_course_.set(2 * PI * true_course / 360.);
-    }
-    if (variation != kInvalidFloat) {
-      variation_.set(2 * PI * variation / 360.);
+    if (variation.is_valid()) {
+      variation_.set(2 * PI * (float)variation / 360.);
     }
   }
 
@@ -293,9 +312,9 @@ bool VTGSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float true_track;
-  float magnetic_track;
-  float ground_speed;
+  Nullable<float> true_track;
+  Nullable<float> magnetic_track;
+  Nullable<float> ground_speed;
   char true_track_symbol;
   char magnetic_track_symbol;
   char ground_speed_knots_unit;
@@ -311,15 +330,15 @@ bool VTGSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   True track made good (empty when stationary)
-      FLDP_OPT(Float, &true_track),
+      FLDP_OPT(Float, true_track.ptr()),
       // 2   T
       FLDP_OPT(Char, &true_track_symbol, 'T'),
       // 3   Magnetic track made good (empty when stationary)
-      FLDP_OPT(Float, &magnetic_track),
+      FLDP_OPT(Float, magnetic_track.ptr()),
       // 4   M
       FLDP_OPT(Char, &magnetic_track_symbol, 'M'),
       // 5   Ground speed, knots (empty when stationary)
-      FLDP_OPT(Float, &ground_speed),
+      FLDP_OPT(Float, ground_speed.ptr()),
       // 6   N
       FLDP_OPT(Char, &ground_speed_knots_unit, 'N')
       // ignore the remaining fields for now
@@ -335,12 +354,12 @@ bool VTGSentenceParser::parse_fields(const char* field_strings,
 
   // set observers
 
-  if (true_track != kInvalidFloat) {
-    true_course_.set(2 * PI * true_track / 360.);
+  if (true_track.is_valid()) {
+    true_course_.set(2 * PI * (float)true_track / 360.);
   }
   // ignore magnetic track for now
-  if (ground_speed != kInvalidFloat) {
-    speed_.set(1852. * ground_speed / 3600.);
+  if (ground_speed.is_valid()) {
+    speed_.set(1852. * (float)ground_speed / 3600.);
   }
 
   return true;
@@ -352,11 +371,11 @@ bool GSVSentenceParser::parse_fields(const char* field_strings,
   bool ok = true;
 
   // True if NMEA 0183 v4.10 format with separate system ID is used
-  static int num_sentences = 0;
-  int sentence_number = 0;
+  static int32_t num_sentences = 0;
+  int32_t sentence_number = 0;
   static bool new_message_format = false;
   static int collected_num_satellites = 0;
-  int num_satellites = 0;
+  int32_t num_satellites = 0;
   static int total_svs_in_view = 0;  // Accumulated from field 3
   static std::vector<GNSSSatellite> satellites;
   GNSSSatellite sentence_satellites[4];
@@ -558,7 +577,8 @@ bool SkyTraqPSTI030SentenceParser::parse_fields(const char* field_strings,
                                                 int num_fields) {
   bool ok = true;
 
-  struct tm time;
+  int32_t hour;
+  int32_t minute;
   float second;
   bool is_valid = false;
   Position position;
@@ -566,6 +586,9 @@ bool SkyTraqPSTI030SentenceParser::parse_fields(const char* field_strings,
   SkyTraqGNSSQuality quality;
   float rtk_age;
   float rtk_ratio;
+  int32_t year;
+  int32_t month;
+  int32_t day;
 
   // Example:
   // $PSTI,030,044606.000,A,2447.0924110,N,12100.5227860,E,103.323,0.00,0.00,0.00,180915,R,1.2,4.2*02
@@ -581,7 +604,7 @@ bool SkyTraqPSTI030SentenceParser::parse_fields(const char* field_strings,
   std::function<bool(const char*)> fps[] = {
       // 1  UTC time  044606.000  UTC time in hhmmss.sss format (000000.00 ~
       // 235959.999)
-      FLDP(Time, &time.tm_hour, &time.tm_min, &second),
+      FLDP(Time, &hour, &minute, &second),
       // 2  Status  A  Status
       // ‘V’ = Navigation receiver warning
       // ‘A’ = Data Valid
@@ -609,7 +632,7 @@ bool SkyTraqPSTI030SentenceParser::parse_fields(const char* field_strings,
       // 10  Up Velocity  0.00  ‘Up’ component of ENU velocity (m/s)
       FLDP(Float, &velocity.up),
       // 11  UTC Date  180915  UTC date of position fix, ddmmyy format
-      FLDP(Date, &time.tm_year, &time.tm_mon, &time.tm_mday),
+      FLDP(Date, &year, &month, &day),
       // 12  Mode indicator  R  Mode indicator
       // ‘N’ = Data not valid
       // ‘A’ = Autonomous mode
@@ -635,7 +658,13 @@ bool SkyTraqPSTI030SentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
+  struct tm time = {};
+  time.tm_hour = hour;
+  time.tm_min = minute;
   time.tm_sec = (int)second;
+  time.tm_year = year;   // ParseDate already adds 100
+  time.tm_mon = month;   // ParseDate already subtracts 1
+  time.tm_mday = day;
   time.tm_isdst = 0;
 
   // notify relevant observers
@@ -658,8 +687,12 @@ bool SkyTraqPSTI032SentenceParser::parse_fields(const char* field_strings,
                                                 int num_fields) {
   bool ok = true;
 
-  struct tm time;
+  int32_t hour;
+  int32_t minute;
   float second;
+  int32_t year;
+  int32_t month;
+  int32_t day;
   bool is_valid = false;
   ENUVector projection;
   SkyTraqGNSSQuality quality;
@@ -679,9 +712,9 @@ bool SkyTraqPSTI032SentenceParser::parse_fields(const char* field_strings,
   std::function<bool(const char*)> fps[] = {
       // 1  UTC time  041457.000  UTC time in hhmmss.sss format
       // (000000.000~235959.999)
-      FLDP(Time, &time.tm_hour, &time.tm_min, &second),
+      FLDP(Time, &hour, &minute, &second),
       // 2  UTC Date  170316  UTC date of position fix, ddmmyy format
-      FLDP(Date, &time.tm_year, &time.tm_mon, &time.tm_mday),
+      FLDP(Date, &year, &month, &day),
       // 3  Status  A
       // Status
       // ‘V’ = Void
@@ -723,7 +756,13 @@ bool SkyTraqPSTI032SentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
+  struct tm time = {};
+  time.tm_hour = hour;
+  time.tm_min = minute;
   time.tm_sec = (int)second;
+  time.tm_year = year;   // ParseDate already adds 100
+  time.tm_mon = month;   // ParseDate already subtracts 1
+  time.tm_mday = day;
   time.tm_isdst = 0;
 
   if (is_valid) {
@@ -742,13 +781,14 @@ bool QuectelPQTMTARSentenceParser::parse_fields(const char* field_strings,
                                                 int num_fields) {
   bool ok = true;
 
-  struct tm time;
+  int32_t hour;
+  int32_t minute;
   float second;
   float base_line_length;
-  int heading_status;
+  int32_t heading_status;
   AttitudeVector attitude_degree;
   AttitudeVector attitude_accuracy_degree;
-  int hdg_num_satellites;
+  int32_t hdg_num_satellites;
   char dummy;
 
   // Example:
@@ -765,7 +805,7 @@ bool QuectelPQTMTARSentenceParser::parse_fields(const char* field_strings,
       FLDP(Char, &dummy, '1'),
       // 2 UTC time 165331.000 UTC time in hhmmss.sss format (000000.000 ~
       // 235959.999)
-      FLDP(Time, &time.tm_hour, &time.tm_min, &second),
+      FLDP(Time, &hour, &minute, &second),
       // 3 Heading status.
       FLDP(Int, &heading_status),
       // 4 Always empty.
@@ -795,6 +835,9 @@ bool QuectelPQTMTARSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
+  struct tm time = {};
+  time.tm_hour = hour;
+  time.tm_min = minute;
   time.tm_sec = (int)second;
   time.tm_isdst = 0;
 
@@ -817,10 +860,10 @@ bool GSASentenceParser::parse_fields(const char* field_strings,
   bool ok = true;
 
   char mode;
-  int fix_type;
-  float pdop;
-  float hdop;
-  float vdop;
+  int32_t fix_type;
+  Nullable<float> pdop;
+  Nullable<float> hdop;
+  Nullable<float> vdop;
 
   // $xxGSA,mode,fix_type,sv1,sv2,...,sv12,pdop,hdop,vdop[,systemId]*cs
   // eg. $GPGSA,A,3,04,05,,09,12,,,24,,,,,2.5,1.3,2.1*39
@@ -836,22 +879,22 @@ bool GSASentenceParser::parse_fields(const char* field_strings,
   ok &= FLDP(Int, &fix_type)(field_strings + field_offsets[2]);
   // Skip satellite IDs (fields 3-14)
   // Parse DOP values — fields 15-17
-  ok &= FLDP_OPT(Float, &pdop)(field_strings + field_offsets[15]);
-  ok &= FLDP_OPT(Float, &hdop)(field_strings + field_offsets[16]);
-  ok &= FLDP_OPT(Float, &vdop)(field_strings + field_offsets[17]);
+  ok &= FLDP_OPT(Float, pdop.ptr())(field_strings + field_offsets[15]);
+  ok &= FLDP_OPT(Float, hdop.ptr())(field_strings + field_offsets[16]);
+  ok &= FLDP_OPT(Float, vdop.ptr())(field_strings + field_offsets[17]);
 
   if (!ok) {
     return false;
   }
 
   fix_type_.set(fix_type);
-  if (pdop != kInvalidFloat) {
+  if (pdop.is_valid()) {
     pdop_.set(pdop);
   }
-  if (hdop != kInvalidFloat) {
+  if (hdop.is_valid()) {
     hdop_.set(hdop);
   }
-  if (vdop != kInvalidFloat) {
+  if (vdop.is_valid()) {
     vdop_.set(vdop);
   }
 
@@ -863,12 +906,12 @@ bool ZDASentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  int hour;
-  int minute;
+  int32_t hour;
+  int32_t minute;
   float second;
-  int day;
-  int month;
-  int year;
+  int32_t day;
+  int32_t month;
+  int32_t year;
 
   // $xxZDA,hhmmss.ss,dd,mm,yyyy,ltzh,ltzn*cs
   // eg. $GPZDA,160012.71,11,03,2004,-1,00*7D
@@ -906,12 +949,12 @@ bool GBSSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  int hour;
-  int minute;
+  int32_t hour;
+  int32_t minute;
   float second;
-  float lat_error;
-  float lon_error;
-  float alt_error;
+  Nullable<float> lat_error;
+  Nullable<float> lon_error;
+  Nullable<float> alt_error;
 
   // $xxGBS,hhmmss.ss,lat_err,lon_err,alt_err,svid,prob,bias,stddev*cs
   // eg. $GPGBS,235458.00,1.4,1.3,3.1,03,,-21.4,3.8*5B
@@ -922,21 +965,21 @@ bool GBSSentenceParser::parse_fields(const char* field_strings,
 
   ok &= FLDP(Time, &hour, &minute, &second)(
       field_strings + field_offsets[1]);
-  ok &= FLDP_OPT(Float, &lat_error)(field_strings + field_offsets[2]);
-  ok &= FLDP_OPT(Float, &lon_error)(field_strings + field_offsets[3]);
-  ok &= FLDP_OPT(Float, &alt_error)(field_strings + field_offsets[4]);
+  ok &= FLDP_OPT(Float, lat_error.ptr())(field_strings + field_offsets[2]);
+  ok &= FLDP_OPT(Float, lon_error.ptr())(field_strings + field_offsets[3]);
+  ok &= FLDP_OPT(Float, alt_error.ptr())(field_strings + field_offsets[4]);
 
   if (!ok) {
     return false;
   }
 
-  if (lat_error != kInvalidFloat) {
+  if (lat_error.is_valid()) {
     lat_error_.set(lat_error);
   }
-  if (lon_error != kInvalidFloat) {
+  if (lon_error.is_valid()) {
     lon_error_.set(lon_error);
   }
-  if (alt_error != kInvalidFloat) {
+  if (alt_error.is_valid()) {
     alt_error_.set(alt_error);
   }
 

--- a/src/sensesp_nmea0183/sentence_parser/navigation_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/navigation_sentence_parser.cpp
@@ -1,6 +1,8 @@
 #include "navigation_sentence_parser.h"
 
 #include "field_parsers.h"
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
 
 namespace sensesp::nmea0183 {
 
@@ -9,9 +11,9 @@ bool HDGSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float heading;
-  float deviation;
-  float variation;
+  Nullable<float> heading;
+  Nullable<float> deviation;
+  Nullable<float> variation;
 
   // $xxHDG,heading,deviation,E/W,variation,E/W*cs
   // eg. $HCHDG,101.1,,,7.1,W*3C
@@ -22,15 +24,15 @@ bool HDGSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   Magnetic sensor heading, degrees
-      FLDP_OPT(Float, &heading),
+      FLDP_OPT(Float, heading.ptr()),
       // 2   Magnetic deviation, degrees
-      FLDP_OPT(Float, &deviation),
+      FLDP_OPT(Float, deviation.ptr()),
       // 3   E/W for deviation
-      FLDP_OPT(EW, &deviation),
+      FLDP_OPT(EW, deviation.ptr()),
       // 4   Magnetic variation, degrees
-      FLDP_OPT(Float, &variation),
+      FLDP_OPT(Float, variation.ptr()),
       // 5   E/W for variation
-      FLDP_OPT(EW, &variation),
+      FLDP_OPT(EW, variation.ptr()),
   };
 
   for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
@@ -41,13 +43,13 @@ bool HDGSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (heading != kInvalidFloat) {
+  if (heading.is_valid()) {
     magnetic_heading_.set(heading * DEG_TO_RAD);
   }
-  if (deviation != kInvalidFloat) {
+  if (deviation.is_valid()) {
     deviation_.set(deviation * DEG_TO_RAD);
   }
-  if (variation != kInvalidFloat) {
+  if (variation.is_valid()) {
     variation_.set(variation * DEG_TO_RAD);
   }
 
@@ -59,10 +61,10 @@ bool VHWSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float true_heading;
-  float magnetic_heading;
-  float speed_knots;
-  float speed_kmh;
+  Nullable<float> true_heading;
+  Nullable<float> magnetic_heading;
+  Nullable<float> speed_knots;
+  Nullable<float> speed_kmh;
   char t_char;
   char m_char;
   char n_char;
@@ -77,19 +79,19 @@ bool VHWSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   True heading, degrees
-      FLDP_OPT(Float, &true_heading),
+      FLDP_OPT(Float, true_heading.ptr()),
       // 2   T = True
       FLDP_OPT(Char, &t_char, 'T'),
       // 3   Magnetic heading, degrees
-      FLDP_OPT(Float, &magnetic_heading),
+      FLDP_OPT(Float, magnetic_heading.ptr()),
       // 4   M = Magnetic
       FLDP_OPT(Char, &m_char, 'M'),
       // 5   Speed, knots
-      FLDP_OPT(Float, &speed_knots),
+      FLDP_OPT(Float, speed_knots.ptr()),
       // 6   N = Knots
       FLDP_OPT(Char, &n_char, 'N'),
       // 7   Speed, km/h
-      FLDP_OPT(Float, &speed_kmh),
+      FLDP_OPT(Float, speed_kmh.ptr()),
       // 8   K = km/h
       FLDP_OPT(Char, &k_char, 'K'),
   };
@@ -102,16 +104,16 @@ bool VHWSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (true_heading != kInvalidFloat) {
+  if (true_heading.is_valid()) {
     true_heading_.set(true_heading * DEG_TO_RAD);
   }
-  if (magnetic_heading != kInvalidFloat) {
+  if (magnetic_heading.is_valid()) {
     magnetic_heading_.set(magnetic_heading * DEG_TO_RAD);
   }
   // Prefer knots; convert to m/s
-  if (speed_knots != kInvalidFloat) {
+  if (speed_knots.is_valid()) {
     water_speed_.set(speed_knots * 1852.0 / 3600.0);
-  } else if (speed_kmh != kInvalidFloat) {
+  } else if (speed_kmh.is_valid()) {
     water_speed_.set(speed_kmh * 1000.0 / 3600.0);
   }
 
@@ -123,9 +125,8 @@ bool DPTSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float depth;
-  float offset;
-  float max_range;
+  Nullable<float> depth;
+  Nullable<float> offset;
 
   // $xxDPT,depth,offset,max_range*cs
   // eg. $SDDPT,12.6,-0.5,100*42
@@ -135,19 +136,19 @@ bool DPTSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  ok &= FLDP_OPT(Float, &depth)(field_strings + field_offsets[1]);
+  ok &= FLDP_OPT(Float, depth.ptr())(field_strings + field_offsets[1]);
   if (num_fields >= 3) {
-    ok &= FLDP_OPT(Float, &offset)(field_strings + field_offsets[2]);
+    ok &= FLDP_OPT(Float, offset.ptr())(field_strings + field_offsets[2]);
   }
 
   if (!ok) {
     return false;
   }
 
-  if (depth != kInvalidFloat) {
+  if (depth.is_valid()) {
     depth_.set(depth);
   }
-  if (offset != kInvalidFloat) {
+  if (offset.is_valid()) {
     offset_.set(offset);
   }
 
@@ -159,9 +160,9 @@ bool DBTSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float depth_feet;
-  float depth_meters;
-  float depth_fathoms;
+  Nullable<float> depth_feet;
+  Nullable<float> depth_meters;
+  Nullable<float> depth_fathoms;
   char f_char;
   char m_char;
   char F_char;
@@ -175,15 +176,15 @@ bool DBTSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   Depth, feet
-      FLDP_OPT(Float, &depth_feet),
+      FLDP_OPT(Float, depth_feet.ptr()),
       // 2   f = feet
       FLDP_OPT(Char, &f_char, 'f'),
       // 3   Depth, meters
-      FLDP_OPT(Float, &depth_meters),
+      FLDP_OPT(Float, depth_meters.ptr()),
       // 4   M = meters
       FLDP_OPT(Char, &m_char, 'M'),
       // 5   Depth, fathoms
-      FLDP_OPT(Float, &depth_fathoms),
+      FLDP_OPT(Float, depth_fathoms.ptr()),
       // 6   F = fathoms
       FLDP_OPT(Char, &F_char, 'F'),
   };
@@ -197,11 +198,11 @@ bool DBTSentenceParser::parse_fields(const char* field_strings,
   }
 
   // Prefer meters; fallback to feet or fathoms
-  if (depth_meters != kInvalidFloat) {
+  if (depth_meters.is_valid()) {
     depth_.set(depth_meters);
-  } else if (depth_feet != kInvalidFloat) {
+  } else if (depth_feet.is_valid()) {
     depth_.set(depth_feet * 0.3048);
-  } else if (depth_fathoms != kInvalidFloat) {
+  } else if (depth_fathoms.is_valid()) {
     depth_.set(depth_fathoms * 1.8288);
   }
 
@@ -248,7 +249,7 @@ bool HDMSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float heading;
+  Nullable<float> heading;
   char m_char;
 
   // $xxHDM,heading,M*cs
@@ -260,7 +261,7 @@ bool HDMSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   Heading, degrees magnetic
-      FLDP_OPT(Float, &heading),
+      FLDP_OPT(Float, heading.ptr()),
       // 2   M = magnetic
       FLDP_OPT(Char, &m_char, 'M'),
   };
@@ -273,7 +274,7 @@ bool HDMSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (heading != kInvalidFloat) {
+  if (heading.is_valid()) {
     magnetic_heading_.set(heading * DEG_TO_RAD);
   }
 
@@ -285,7 +286,7 @@ bool HDTSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float heading;
+  Nullable<float> heading;
   char t_char;
 
   // $xxHDT,heading,T*cs
@@ -297,7 +298,7 @@ bool HDTSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   Heading, degrees true
-      FLDP_OPT(Float, &heading),
+      FLDP_OPT(Float, heading.ptr()),
       // 2   T = true
       FLDP_OPT(Char, &t_char, 'T'),
   };
@@ -310,7 +311,7 @@ bool HDTSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (heading != kInvalidFloat) {
+  if (heading.is_valid()) {
     true_heading_.set(heading * DEG_TO_RAD);
   }
 

--- a/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.cpp
@@ -1,6 +1,9 @@
 #include "waypoint_sentence_parser.h"
 
 #include "field_parsers.h"
+#include "sensesp/types/nullable.h"
+
+using sensesp::Nullable;
 
 namespace sensesp::nmea0183 {
 
@@ -10,15 +13,15 @@ bool RMBSentenceParser::parse_fields(const char* field_strings,
   bool ok = true;
 
   bool is_valid;
-  float xte;
+  Nullable<float> xte;
   char steer_dir;
   String origin_wp;
   String dest_wp;
-  double dest_lat;
-  double dest_lon;
-  float range_nm;
-  float bearing;
-  float closing_velocity;
+  Nullable<double> dest_lat;
+  Nullable<double> dest_lon;
+  Nullable<float> range_nm;
+  Nullable<float> bearing;
+  Nullable<float> closing_velocity;
   char arrival_status;
 
   // $xxRMB,A,xte,L/R,origin_wp,dest_wp,lat,N/S,lon,E/W,range,bearing,
@@ -33,7 +36,7 @@ bool RMBSentenceParser::parse_fields(const char* field_strings,
       // 1   Status A=active, V=void
       FLDP(AV, &is_valid),
       // 2   Cross-track error, nautical miles
-      FLDP_OPT(Float, &xte),
+      FLDP_OPT(Float, xte.ptr()),
       // 3   Direction to steer, L/R
       FLDP_OPT(Char, &steer_dir, 255),
       // 4   Origin waypoint ID
@@ -41,19 +44,19 @@ bool RMBSentenceParser::parse_fields(const char* field_strings,
       // 5   Destination waypoint ID
       FLDP_OPT(String, &dest_wp),
       // 6   Destination latitude
-      FLDP_OPT(LatLon, &dest_lat),
+      FLDP_OPT(LatLon, dest_lat.ptr()),
       // 7   N/S
-      FLDP_OPT(NS, &dest_lat),
+      FLDP_OPT(NS, dest_lat.ptr()),
       // 8   Destination longitude
-      FLDP_OPT(LatLon, &dest_lon),
+      FLDP_OPT(LatLon, dest_lon.ptr()),
       // 9   E/W
-      FLDP_OPT(EW, &dest_lon),
+      FLDP_OPT(EW, dest_lon.ptr()),
       // 10  Range to destination, nautical miles
-      FLDP_OPT(Float, &range_nm),
+      FLDP_OPT(Float, range_nm.ptr()),
       // 11  Bearing to destination, degrees true
-      FLDP_OPT(Float, &bearing),
+      FLDP_OPT(Float, bearing.ptr()),
       // 12  Destination closing velocity, knots
-      FLDP_OPT(Float, &closing_velocity),
+      FLDP_OPT(Float, closing_velocity.ptr()),
       // 13  Arrival status (A=arrived, V=not arrived)
       FLDP_OPT(Char, &arrival_status, 255),
   };
@@ -66,21 +69,21 @@ bool RMBSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (xte != kInvalidFloat) {
-    float signed_xte = xte * 1852.0;  // NM to meters
+  if (xte.is_valid()) {
+    float signed_xte = (float)xte * 1852.0;  // NM to meters
     if (steer_dir == 'L') {
       signed_xte = -signed_xte;
     }
     cross_track_error_.set(signed_xte);
   }
-  if (bearing != kInvalidFloat) {
-    bearing_to_destination_.set(bearing * DEG_TO_RAD);
+  if (bearing.is_valid()) {
+    bearing_to_destination_.set((float)bearing * DEG_TO_RAD);
   }
-  if (range_nm != kInvalidFloat) {
-    range_to_destination_.set(range_nm * 1852.0);
+  if (range_nm.is_valid()) {
+    range_to_destination_.set((float)range_nm * 1852.0);
   }
-  if (closing_velocity != kInvalidFloat) {
-    destination_closing_velocity_.set(closing_velocity * 1852.0 / 3600.0);
+  if (closing_velocity.is_valid()) {
+    destination_closing_velocity_.set((float)closing_velocity * 1852.0 / 3600.0);
   }
   if (dest_wp.length() > 0) {
     destination_waypoint_id_.set(dest_wp);
@@ -96,17 +99,17 @@ bool APBSentenceParser::parse_fields(const char* field_strings,
 
   bool status1;
   bool status2;
-  float xte;
+  Nullable<float> xte;
   char steer_dir;
   char xte_units;
   char arrival_circle;
   char perpendicular;
-  float bearing_origin_dest;
+  Nullable<float> bearing_origin_dest;
   char bearing_od_type;
   String dest_wp;
-  float bearing_pos_dest;
+  Nullable<float> bearing_pos_dest;
   char bearing_pd_type;
-  float heading_to_steer;
+  Nullable<float> heading_to_steer;
   char heading_type;
 
   // $xxAPB,A,A,xte,L/R,N,A/V,A/V,bearing_od,M/T,dest_wp,bearing_pd,M/T,
@@ -123,7 +126,7 @@ bool APBSentenceParser::parse_fields(const char* field_strings,
       // 2   Status 2 (A=active)
       FLDP(AV, &status2),
       // 3   Cross-track error magnitude
-      FLDP_OPT(Float, &xte),
+      FLDP_OPT(Float, xte.ptr()),
       // 4   Direction to steer, L/R
       FLDP_OPT(Char, &steer_dir, 255),
       // 5   Cross-track error units, N=nautical miles
@@ -133,17 +136,17 @@ bool APBSentenceParser::parse_fields(const char* field_strings,
       // 7   Perpendicular passed (A/V)
       FLDP_OPT(Char, &perpendicular, 255),
       // 8   Bearing origin to destination
-      FLDP_OPT(Float, &bearing_origin_dest),
+      FLDP_OPT(Float, bearing_origin_dest.ptr()),
       // 9   M/T (magnetic or true)
       FLDP_OPT(Char, &bearing_od_type, 255),
       // 10  Destination waypoint ID
       FLDP_OPT(String, &dest_wp),
       // 11  Bearing, present position to destination
-      FLDP_OPT(Float, &bearing_pos_dest),
+      FLDP_OPT(Float, bearing_pos_dest.ptr()),
       // 12  M/T
       FLDP_OPT(Char, &bearing_pd_type, 255),
       // 13  Heading to steer to destination
-      FLDP_OPT(Float, &heading_to_steer),
+      FLDP_OPT(Float, heading_to_steer.ptr()),
       // 14  M/T
       FLDP_OPT(Char, &heading_type, 255),
   };
@@ -156,15 +159,15 @@ bool APBSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (xte != kInvalidFloat) {
-    float signed_xte = xte * 1852.0;  // NM to meters
+  if (xte.is_valid()) {
+    float signed_xte = (float)xte * 1852.0;  // NM to meters
     if (steer_dir == 'L') {
       signed_xte = -signed_xte;
     }
     cross_track_error_.set(signed_xte);
   }
-  if (heading_to_steer != kInvalidFloat) {
-    heading_to_steer_.set(heading_to_steer * DEG_TO_RAD);
+  if (heading_to_steer.is_valid()) {
+    heading_to_steer_.set((float)heading_to_steer * DEG_TO_RAD);
   }
 
   return true;
@@ -175,14 +178,14 @@ bool BWCSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  int hour;
-  int minute;
+  int32_t hour;
+  int32_t minute;
   float second;
-  double lat;
-  double lon;
-  float bearing_true;
-  float bearing_mag;
-  float distance_nm;
+  Nullable<double> lat;
+  Nullable<double> lon;
+  Nullable<float> bearing_true;
+  Nullable<float> bearing_mag;
+  Nullable<float> distance_nm;
   String waypoint_id;
   char t_char;
   char m_char;
@@ -200,23 +203,23 @@ bool BWCSentenceParser::parse_fields(const char* field_strings,
       // 1   UTC time
       FLDP_OPT(Time, &hour, &minute, &second),
       // 2   Waypoint latitude
-      FLDP_OPT(LatLon, &lat),
+      FLDP_OPT(LatLon, lat.ptr()),
       // 3   N/S
-      FLDP_OPT(NS, &lat),
+      FLDP_OPT(NS, lat.ptr()),
       // 4   Waypoint longitude
-      FLDP_OPT(LatLon, &lon),
+      FLDP_OPT(LatLon, lon.ptr()),
       // 5   E/W
-      FLDP_OPT(EW, &lon),
+      FLDP_OPT(EW, lon.ptr()),
       // 6   Bearing, true
-      FLDP_OPT(Float, &bearing_true),
+      FLDP_OPT(Float, bearing_true.ptr()),
       // 7   T = true
       FLDP_OPT(Char, &t_char, 'T'),
       // 8   Bearing, magnetic
-      FLDP_OPT(Float, &bearing_mag),
+      FLDP_OPT(Float, bearing_mag.ptr()),
       // 9   M = magnetic
       FLDP_OPT(Char, &m_char, 'M'),
       // 10  Distance, nautical miles
-      FLDP_OPT(Float, &distance_nm),
+      FLDP_OPT(Float, distance_nm.ptr()),
       // 11  N = nautical miles
       FLDP_OPT(Char, &n_char, 'N'),
       // 12  Waypoint ID
@@ -231,22 +234,22 @@ bool BWCSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (bearing_true != kInvalidFloat) {
-    bearing_true_.set(bearing_true * DEG_TO_RAD);
+  if (bearing_true.is_valid()) {
+    bearing_true_.set((float)bearing_true * DEG_TO_RAD);
   }
-  if (bearing_mag != kInvalidFloat) {
-    bearing_magnetic_.set(bearing_mag * DEG_TO_RAD);
+  if (bearing_mag.is_valid()) {
+    bearing_magnetic_.set((float)bearing_mag * DEG_TO_RAD);
   }
-  if (distance_nm != kInvalidFloat) {
-    distance_.set(distance_nm * 1852.0);
+  if (distance_nm.is_valid()) {
+    distance_.set((float)distance_nm * 1852.0);
   }
   if (waypoint_id.length() > 0) {
     waypoint_id_.set(waypoint_id);
   }
-  if (lat != kInvalidDouble && lon != kInvalidDouble) {
+  if (lat.is_valid() && lon.is_valid()) {
     Position pos;
-    pos.latitude = lat;
-    pos.longitude = lon;
+    pos.latitude = (double)lat;
+    pos.longitude = (double)lon;
     pos.altitude = kPositionInvalidAltitude;
     waypoint_position_.set(pos);
   }
@@ -306,8 +309,8 @@ bool RTESentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  int num_sentences;
-  int sentence_number;
+  int32_t num_sentences;
+  int32_t sentence_number;
   char route_type;
   String route_id;
 

--- a/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.h
+++ b/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.h
@@ -1,6 +1,8 @@
 #ifndef SENSESP_NMEA0183_WAYPOINT_SENTENCE_PARSER_H_
 #define SENSESP_NMEA0183_WAYPOINT_SENTENCE_PARSER_H_
 
+#include <cstdint>
+
 #include "field_parsers.h"
 #include "sensesp/system/observablevalue.h"
 #include "sensesp/types/position.h"
@@ -75,7 +77,7 @@ class RTESentenceParser : public SentenceParser {
   ObservableValue<std::vector<String>> waypoints_;
 
  private:
-  int total_sentences_ = 0;
+  int32_t total_sentences_ = 0;
   std::vector<String> accumulated_waypoints_;
 };
 

--- a/src/sensesp_nmea0183/sentence_parser/weather_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/weather_sentence_parser.cpp
@@ -1,6 +1,8 @@
 #include "weather_sentence_parser.h"
 
 #include "field_parsers.h"
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
 
 namespace sensesp::nmea0183 {
 
@@ -9,22 +11,21 @@ bool MDASentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float pressure_inhg;
-  float pressure_bars;
-  float air_temp;
-  float water_temp;
-  float humidity;
-  float dew_point;
-  float wind_dir_true;
-  float wind_dir_mag;
-  float abs_humidity;
-  float wind_speed_kn;
-  float wind_speed_ms;
+  Nullable<float> pressure_inhg;
+  Nullable<float> pressure_bars;
+  Nullable<float> air_temp;
+  Nullable<float> water_temp;
+  Nullable<float> humidity;
+  Nullable<float> dew_point;
+  Nullable<float> wind_dir_true;
+  Nullable<float> wind_dir_mag;
+  Nullable<float> abs_humidity;
+  Nullable<float> wind_speed_kn;
+  Nullable<float> wind_speed_ms;
   char i_char;
   char b_char;
   char c1_char;
   char c2_char;
-  char h_char;
   char c3_char;
   char t_char;
   char m_char;
@@ -42,43 +43,43 @@ bool MDASentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   Barometric pressure, inches of mercury
-      FLDP_OPT(Float, &pressure_inhg),
+      FLDP_OPT(Float, pressure_inhg.ptr()),
       // 2   I = inches of mercury
       FLDP_OPT(Char, &i_char, 'I'),
       // 3   Barometric pressure, bars
-      FLDP_OPT(Float, &pressure_bars),
+      FLDP_OPT(Float, pressure_bars.ptr()),
       // 4   B = bars
       FLDP_OPT(Char, &b_char, 'B'),
       // 5   Air temperature, Celsius
-      FLDP_OPT(Float, &air_temp),
+      FLDP_OPT(Float, air_temp.ptr()),
       // 6   C = Celsius
       FLDP_OPT(Char, &c1_char, 'C'),
       // 7   Water temperature, Celsius
-      FLDP_OPT(Float, &water_temp),
+      FLDP_OPT(Float, water_temp.ptr()),
       // 8   C = Celsius
       FLDP_OPT(Char, &c2_char, 'C'),
       // 9   Relative humidity, percent
-      FLDP_OPT(Float, &humidity),
+      FLDP_OPT(Float, humidity.ptr()),
       // 10  Absolute humidity (rarely populated, ignored)
-      FLDP_OPT(Float, &abs_humidity),
+      FLDP_OPT(Float, abs_humidity.ptr()),
       // 11  Dew point, Celsius
-      FLDP_OPT(Float, &dew_point),
+      FLDP_OPT(Float, dew_point.ptr()),
       // 12  C = Celsius
       FLDP_OPT(Char, &c3_char, 'C'),
       // 13  Wind direction, degrees true
-      FLDP_OPT(Float, &wind_dir_true),
+      FLDP_OPT(Float, wind_dir_true.ptr()),
       // 14  T = true
       FLDP_OPT(Char, &t_char, 'T'),
       // 15  Wind direction, degrees magnetic
-      FLDP_OPT(Float, &wind_dir_mag),
+      FLDP_OPT(Float, wind_dir_mag.ptr()),
       // 16  M = magnetic
       FLDP_OPT(Char, &m_char, 'M'),
       // 17  Wind speed, knots
-      FLDP_OPT(Float, &wind_speed_kn),
+      FLDP_OPT(Float, wind_speed_kn.ptr()),
       // 18  N = knots
       FLDP_OPT(Char, &n_char, 'N'),
       // 19  Wind speed, m/s
-      FLDP_OPT(Float, &wind_speed_ms),
+      FLDP_OPT(Float, wind_speed_ms.ptr()),
       // 20  M = m/s
       FLDP_OPT(Char, &ms_char, 'M'),
   };
@@ -92,31 +93,31 @@ bool MDASentenceParser::parse_fields(const char* field_strings,
   }
 
   // Prefer bars; fallback to inches of mercury
-  if (pressure_bars != kInvalidFloat) {
+  if (pressure_bars.is_valid()) {
     barometric_pressure_.set(pressure_bars * 100000.0);
-  } else if (pressure_inhg != kInvalidFloat) {
+  } else if (pressure_inhg.is_valid()) {
     barometric_pressure_.set(pressure_inhg * 3386.389);
   }
 
-  if (air_temp != kInvalidFloat) {
+  if (air_temp.is_valid()) {
     air_temperature_.set(air_temp + 273.15);
   }
-  if (water_temp != kInvalidFloat) {
+  if (water_temp.is_valid()) {
     water_temperature_.set(water_temp + 273.15);
   }
-  if (humidity != kInvalidFloat) {
+  if (humidity.is_valid()) {
     relative_humidity_.set(humidity / 100.0);
   }
-  if (dew_point != kInvalidFloat) {
+  if (dew_point.is_valid()) {
     dew_point_.set(dew_point + 273.15);
   }
-  if (wind_dir_true != kInvalidFloat) {
+  if (wind_dir_true.is_valid()) {
     true_wind_direction_.set(wind_dir_true * DEG_TO_RAD);
   }
   // Prefer m/s; fallback to knots
-  if (wind_speed_ms != kInvalidFloat) {
+  if (wind_speed_ms.is_valid()) {
     true_wind_speed_.set(wind_speed_ms);
-  } else if (wind_speed_kn != kInvalidFloat) {
+  } else if (wind_speed_kn.is_valid()) {
     true_wind_speed_.set(wind_speed_kn * 1852.0 / 3600.0);
   }
 

--- a/src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/wind_sentence_parser.cpp
@@ -1,16 +1,19 @@
 #include "wind_sentence_parser.h"
 
 #include "field_parsers.h"
+#include "sensesp/types/nullable.h"
+using sensesp::Nullable;
 
 namespace sensesp::nmea0183 {
 
 bool MWVSentenceParser::parse_fields(const char* field_strings,
                                      const int field_offsets[],
                                      int num_fields) {
-  bool ok = true;
-
-  float wind_speed;
-  float wind_angle;
+  Nullable<float> wind_speed;
+  Nullable<float> wind_angle;
+  char r_value;
+  char units;
+  char a_value;
 
   //      0,  1,2,  3,4,5
   // $xxMWV,a.a,R,s.s,N,A*hh
@@ -21,23 +24,19 @@ bool MWVSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  char r_value;
-  char units;
-  char a_value;
-
   std::function<bool(const char*)> fps[] = {// 1 a.a = Apparent wind angle
-                                            FLDP_OPT(Float, &wind_angle),
+                                            FLDP_OPT(Float, wind_angle.ptr()),
                                             // 2 R = Relative wind speed
                                             FLDP_OPT(Char, &r_value, 'R'),
                                             // 3 s.s = Wind speed
-                                            FLDP_OPT(Float, &wind_speed),
+                                            FLDP_OPT(Float, wind_speed.ptr()),
                                             // 4 N = Wind speed units
                                             FLDP_OPT(Char, &units, 255),
                                             // 5 A = Valid
                                             FLDP_OPT(Char, &a_value, 'A')};
 
-  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]);
-       i++) {
+  bool ok = true;
+  for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
     ok &= fps[i - 1](field_strings + field_offsets[i]);
   }
 
@@ -45,12 +44,16 @@ bool MWVSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (!ConvertSpeedToMs(&wind_speed, units)) {
-    return false;
+  if (wind_speed.is_valid()) {
+    float speed = wind_speed;
+    if (!ConvertSpeedToMs(&speed, units)) {
+      return false;
+    }
+    apparent_wind_speed_.set(speed);
   }
-
-  apparent_wind_speed_.set(wind_speed);
-  apparent_wind_angle_.set(wind_angle * DEG_TO_RAD);
+  if (wind_angle.is_valid()) {
+    apparent_wind_angle_.set(wind_angle * DEG_TO_RAD);
+  }
 
   return true;
 }
@@ -58,10 +61,11 @@ bool MWVSentenceParser::parse_fields(const char* field_strings,
 bool TrueWindMWVSentenceParser::parse_fields(const char* field_strings,
                                               const int field_offsets[],
                                               int num_fields) {
-  bool ok = true;
-
-  float wind_speed;
-  float wind_angle;
+  Nullable<float> wind_speed;
+  Nullable<float> wind_angle;
+  char t_value;
+  char units;
+  char a_value;
 
   //      0,  1,2,  3,4,5
   // $xxMWV,a.a,T,s.s,N,A*hh
@@ -72,21 +76,18 @@ bool TrueWindMWVSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  char t_value;
-  char units;
-  char a_value;
-
   std::function<bool(const char*)> fps[] = {// 1 a.a = True wind direction
-                                            FLDP_OPT(Float, &wind_angle),
+                                            FLDP_OPT(Float, wind_angle.ptr()),
                                             // 2 T = True wind
                                             FLDP_OPT(Char, &t_value, 'T'),
                                             // 3 s.s = Wind speed
-                                            FLDP_OPT(Float, &wind_speed),
+                                            FLDP_OPT(Float, wind_speed.ptr()),
                                             // 4 N = Wind speed units
                                             FLDP_OPT(Char, &units, 255),
                                             // 5 A = Valid
                                             FLDP_OPT(Char, &a_value, 'A')};
 
+  bool ok = true;
   for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
     ok &= fps[i - 1](field_strings + field_offsets[i]);
   }
@@ -95,12 +96,16 @@ bool TrueWindMWVSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (!ConvertSpeedToMs(&wind_speed, units)) {
-    return false;
+  if (wind_speed.is_valid()) {
+    float speed = wind_speed;
+    if (!ConvertSpeedToMs(&speed, units)) {
+      return false;
+    }
+    true_wind_speed_.set(speed);
   }
-
-  true_wind_speed_.set(wind_speed);
-  true_wind_direction_.set(wind_angle * DEG_TO_RAD);
+  if (wind_angle.is_valid()) {
+    true_wind_direction_.set(wind_angle * DEG_TO_RAD);
+  }
 
   return true;
 }
@@ -110,10 +115,10 @@ bool MWDSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float true_direction;
-  float magnetic_direction;
-  float speed_knots;
-  float speed_ms;
+  Nullable<float> true_direction;
+  Nullable<float> magnetic_direction;
+  Nullable<float> speed_knots;
+  Nullable<float> speed_ms;
   char t_char;
   char m_char;
   char n_char;
@@ -128,19 +133,19 @@ bool MWDSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   Wind direction, degrees true
-      FLDP_OPT(Float, &true_direction),
+      FLDP_OPT(Float, true_direction.ptr()),
       // 2   T = true
       FLDP_OPT(Char, &t_char, 'T'),
       // 3   Wind direction, degrees magnetic
-      FLDP_OPT(Float, &magnetic_direction),
+      FLDP_OPT(Float, magnetic_direction.ptr()),
       // 4   M = magnetic
       FLDP_OPT(Char, &m_char, 'M'),
       // 5   Wind speed, knots
-      FLDP_OPT(Float, &speed_knots),
+      FLDP_OPT(Float, speed_knots.ptr()),
       // 6   N = knots
       FLDP_OPT(Char, &n_char, 'N'),
       // 7   Wind speed, m/s
-      FLDP_OPT(Float, &speed_ms),
+      FLDP_OPT(Float, speed_ms.ptr()),
       // 8   M = m/s
       FLDP_OPT(Char, &ms_char, 'M'),
   };
@@ -153,13 +158,13 @@ bool MWDSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (true_direction != kInvalidFloat) {
+  if (true_direction.is_valid()) {
     true_wind_direction_.set(true_direction * DEG_TO_RAD);
   }
   // Prefer m/s; fallback to knots
-  if (speed_ms != kInvalidFloat) {
+  if (speed_ms.is_valid()) {
     true_wind_speed_.set(speed_ms);
-  } else if (speed_knots != kInvalidFloat) {
+  } else if (speed_knots.is_valid()) {
     true_wind_speed_.set(speed_knots * 1852.0 / 3600.0);
   }
 
@@ -171,11 +176,11 @@ bool VWRSentenceParser::parse_fields(const char* field_strings,
                                      int num_fields) {
   bool ok = true;
 
-  float angle;
+  Nullable<float> angle;
   char lr_char;
-  float speed_knots;
-  float speed_ms;
-  float speed_kmh;
+  Nullable<float> speed_knots;
+  Nullable<float> speed_ms;
+  Nullable<float> speed_kmh;
   char n_char;
   char ms_char;
   char k_char;
@@ -189,19 +194,19 @@ bool VWRSentenceParser::parse_fields(const char* field_strings,
 
   std::function<bool(const char*)> fps[] = {
       // 1   Wind angle, 0-180 degrees
-      FLDP_OPT(Float, &angle),
+      FLDP_OPT(Float, angle.ptr()),
       // 2   L = port, R = starboard
       FLDP_OPT(Char, &lr_char, 255),
       // 3   Wind speed, knots
-      FLDP_OPT(Float, &speed_knots),
+      FLDP_OPT(Float, speed_knots.ptr()),
       // 4   N = knots
       FLDP_OPT(Char, &n_char, 'N'),
       // 5   Wind speed, m/s
-      FLDP_OPT(Float, &speed_ms),
+      FLDP_OPT(Float, speed_ms.ptr()),
       // 6   M = m/s
       FLDP_OPT(Char, &ms_char, 'M'),
       // 7   Wind speed, km/h
-      FLDP_OPT(Float, &speed_kmh),
+      FLDP_OPT(Float, speed_kmh.ptr()),
       // 8   K = km/h
       FLDP_OPT(Char, &k_char, 'K'),
   };
@@ -214,7 +219,7 @@ bool VWRSentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  if (angle != kInvalidFloat) {
+  if (angle.is_valid()) {
     float signed_angle = angle * DEG_TO_RAD;
     if (lr_char == 'L') {
       signed_angle = -signed_angle;
@@ -223,11 +228,11 @@ bool VWRSentenceParser::parse_fields(const char* field_strings,
   }
 
   // Prefer m/s; fallback to knots, then km/h
-  if (speed_ms != kInvalidFloat) {
+  if (speed_ms.is_valid()) {
     apparent_wind_speed_.set(speed_ms);
-  } else if (speed_knots != kInvalidFloat) {
+  } else if (speed_knots.is_valid()) {
     apparent_wind_speed_.set(speed_knots * 1852.0 / 3600.0);
-  } else if (speed_kmh != kInvalidFloat) {
+  } else if (speed_kmh.is_valid()) {
     apparent_wind_speed_.set(speed_kmh * 1000.0 / 3600.0);
   }
 

--- a/test/test_dbt_mtw/test_dbt_mtw.cpp
+++ b/test/test_dbt_mtw/test_dbt_mtw.cpp
@@ -24,7 +24,7 @@ void tearDown(void) {
 
 void test_dbt_all_units(void) {
   // DBT with all three depth units
-  parser->set("$SDDBT,41.3,f,12.6,M,6.9,F*05");
+  parser->set("$SDDBT,41.3,f,12.6,M,6.9,F*0A");
 
   // Should prefer meters
   TEST_ASSERT_FLOAT_WITHIN(0.01, 12.6, dbt->depth_.get());
@@ -33,7 +33,7 @@ void test_dbt_all_units(void) {
 
 void test_dbt_feet_only(void) {
   // DBT with only feet populated (meters field empty)
-  parser->set("$SDDBT,41.3,f,,M,,F*3E");
+  parser->set("$SDDBT,41.3,f,,M,,F*30");
 
   // Should convert feet to meters: 41.3 * 0.3048 = 12.588
   TEST_ASSERT_FLOAT_WITHIN(0.01, 12.588, dbt->depth_.get());
@@ -48,7 +48,7 @@ void test_dbt_invalid_checksum(void) {
 
 void test_mtw_celsius_to_kelvin(void) {
   // MTW: 17.8 C should convert to 290.95 K
-  parser->set("$YXMTW,17.8,C*1B");
+  parser->set("$YXMTW,17.8,C*1C");
 
   TEST_ASSERT_FLOAT_WITHIN(0.01, 290.95, mtw->water_temperature_.get());
   TEST_ASSERT_EQUAL_INT(1, mtw->get_rx_count());
@@ -56,7 +56,7 @@ void test_mtw_celsius_to_kelvin(void) {
 
 void test_mtw_zero_celsius(void) {
   // 0 C = 273.15 K
-  parser->set("$YXMTW,0.0,C*04");
+  parser->set("$YXMTW,0.0,C*22");
 
   TEST_ASSERT_FLOAT_WITHIN(0.01, 273.15, mtw->water_temperature_.get());
 }

--- a/test/test_gga/test_gga.cpp
+++ b/test/test_gga/test_gga.cpp
@@ -41,7 +41,7 @@ void test_gga_no_fix_parses_quality(void) {
   // GGA with no fix has empty position fields — optional field parsers accept
   // these, so the sentence parses and quality=0 is emitted.
   parser->set(
-      "$GNGGA,121224.00,,,,,,0,00,99.99,,,,,,*7E");
+      "$GNGGA,121224.00,,,,,0,00,99.99,,,,,,*7E");
 
   TEST_ASSERT_EQUAL_INT(1, gga->get_rx_count());
   TEST_ASSERT_EQUAL_INT(0, gga->quality_.get());

--- a/test/test_optional_fields/test_optional_fields.cpp
+++ b/test/test_optional_fields/test_optional_fields.cpp
@@ -72,7 +72,7 @@ void test_vtg_empty_track(void) {
 void test_gga_no_fix_empty_position(void) {
   // Position, altitude, geoidal separation, DGPS fields all empty
   parser->set(
-      "$GNGGA,121224.00,,,,,,0,00,99.99,,,,,,*7E");
+      "$GNGGA,121224.00,,,,,0,00,99.99,,,,,,*7E");
 
   TEST_ASSERT_EQUAL_INT(1, gga->get_rx_count());
   TEST_ASSERT_EQUAL_INT(0, gga->quality_.get());


### PR DESCRIPTION
## Why

The parsers represented "no value" two different ways: sentinel constants (`kInvalidFloat = numeric_limits<float>::lowest()`, `kInvalidInt = INT_MIN`, …) in most field parsers, and `Nullable<T>` in `GNSSSatellite`. Sentinels are fragile — consumers must remember to compare against magic constants, with a theoretical collision risk against real measurements. The `parse_fields()` implementations had also drifted into several styles, raising the bar for contributors.

## What

- **Field parsers** write `Nullable<T>::invalid()` on empty input instead of sentinel constants; the constants are removed.
- **Concrete parsers** declare `Nullable<T>` locals for optional fields, pass `.ptr()` to the field parsers, and guard each emit with `is_valid()`. Required fields stay raw.
- **Standardized `parse_fields()`** on the lambda-array + `FLDP`/`FLDP_OPT` loop pattern across all sentence types.
- **`int` → `int32_t`** for fields parsed via `ParseInt`/`ParseTime`/`ParseDate`, for fixed-width portability.

The public `ObservableValue<T>` API is unchanged.

This also repairs pre-existing broken test fixtures that prevented the suites from passing on hardware (they had never been run on a device): four wrong checksums (DBT/MTW) and a malformed GGA no-fix sentence whose stray comma left the required fix-quality field empty. See the dedicated commit for details.

## Verification

Full Unity suite on a HALMET (ESP32): **44/44 across 11 suites**, including the `test_gsv` / `test_gsv_midcycle` suites added on `main` — this branch was rebased onto current `main` and the GSV parser reconciled (upstream's cycle-detection rewrite kept, migration's `int32_t` typing applied).

Closes #31. Closes #32 (code standardization; the contributor documentation for the canonical pattern is in the docs PR for #35).
