### PR TITLE
RTE: discard interrupted multi-sentence sequences

### DIFF
--- a/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.cpp
@@ -304,6 +304,11 @@ bool WPLSentenceParser::parse_fields(const char* field_strings,
   return true;
 }
 
+void RTESentenceParser::reset_sequence() {
+  accumulated_waypoints_.clear();
+  expected_sentence_number_ = 0;
+}
+
 bool RTESentenceParser::parse_fields(const char* field_strings,
                                      const int field_offsets[],
                                      int num_fields) {
@@ -331,11 +336,31 @@ bool RTESentenceParser::parse_fields(const char* field_strings,
     return false;
   }
 
-  // If this is the first sentence, reset the accumulator
+  uint32_t now = now_ms_();
+
+  // A sequence that has gone quiet for too long is stale: drop its partial
+  // state so waypoints from a fresh sequence are not appended to it.
+  if (expected_sentence_number_ != 0 &&
+      now - last_sentence_time_ > sequence_timeout_ms_) {
+    reset_sequence();
+  }
+
   if (sentence_number == 1) {
     accumulated_waypoints_.clear();
     total_sentences_ = num_sentences;
+    accumulated_route_id_ = route_id;
+    expected_sentence_number_ = 1;
+  } else if (expected_sentence_number_ == 0 ||
+             sentence_number != expected_sentence_number_ ||
+             num_sentences != total_sentences_ ||
+             route_id != accumulated_route_id_) {
+    // The in-progress sequence is broken (a gap, a conflicting sentence count,
+    // or a different route). Discard it and wait for a fresh first sentence.
+    reset_sequence();
+    return true;
   }
+
+  last_sentence_time_ = now;
 
   // Accumulate waypoint IDs from remaining fields
   for (int i = 5; i < num_fields; i++) {
@@ -347,10 +372,13 @@ bool RTESentenceParser::parse_fields(const char* field_strings,
     }
   }
 
-  // Emit when the last sentence in the cycle is received
+  expected_sentence_number_ = sentence_number + 1;
+
+  // Emit when the last sentence of a complete, consistent sequence is received.
   if (sentence_number == total_sentences_) {
-    route_id_.set(route_id);
+    route_id_.set(accumulated_route_id_);
     waypoints_.set(accumulated_waypoints_);
+    reset_sequence();
   }
 
   return true;

--- a/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.h
+++ b/src/sensesp_nmea0183/sentence_parser/waypoint_sentence_parser.h
@@ -2,6 +2,7 @@
 #define SENSESP_NMEA0183_WAYPOINT_SENTENCE_PARSER_H_
 
 #include <cstdint>
+#include <functional>
 
 #include "field_parsers.h"
 #include "sensesp/system/observablevalue.h"
@@ -68,7 +69,16 @@ class WPLSentenceParser : public SentenceParser {
 /// Parser for RTE - Routes (multi-sentence)
 class RTESentenceParser : public SentenceParser {
  public:
-  RTESentenceParser(NMEA0183Parser* nmea) : SentenceParser(nmea) {}
+  /// Maximum gap between accepted sentences before a partial sequence is
+  /// considered stale and discarded.
+  static constexpr uint32_t kDefaultSequenceTimeoutMs = 5000;
+
+  RTESentenceParser(NMEA0183Parser* nmea,
+                    uint32_t sequence_timeout_ms = kDefaultSequenceTimeoutMs,
+                    std::function<uint32_t()> clock = millis)
+      : SentenceParser(nmea),
+        sequence_timeout_ms_{sequence_timeout_ms},
+        now_ms_{clock} {}
   bool parse_fields(const char* field_strings, const int field_offsets[],
                     int num_fields) override final;
   const char* sentence_address() override { return "..RTE"; }
@@ -77,8 +87,15 @@ class RTESentenceParser : public SentenceParser {
   ObservableValue<std::vector<String>> waypoints_;
 
  private:
+  void reset_sequence();
+
   int32_t total_sentences_ = 0;
+  int32_t expected_sentence_number_ = 0;
+  String accumulated_route_id_;
   std::vector<String> accumulated_waypoints_;
+  uint32_t last_sentence_time_ = 0;
+  uint32_t sequence_timeout_ms_;
+  std::function<uint32_t()> now_ms_;
 };
 
 }  // namespace sensesp::nmea0183

--- a/test/test_rte/test_rte.cpp
+++ b/test/test_rte/test_rte.cpp
@@ -8,10 +8,14 @@ using namespace sensesp::nmea0183;
 
 static NMEA0183Parser* parser;
 static RTESentenceParser* rte;
+static uint32_t fake_millis;
 
 void setUp(void) {
+  fake_millis = 0;
   parser = new NMEA0183Parser();
-  rte = new RTESentenceParser(parser);
+  rte = new RTESentenceParser(parser,
+                              RTESentenceParser::kDefaultSequenceTimeoutMs,
+                              []() { return fake_millis; });
 }
 
 void tearDown(void) {
@@ -47,6 +51,54 @@ void test_rte_multi_sentence(void) {
   TEST_ASSERT_EQUAL_STRING("OCEAI", wps[4].c_str());
 }
 
+void test_rte_gap_discards_partial(void) {
+  parser->set("$GPRTE,3,1,c,0,PBRCPK,CPNPT*44");  // first of 3
+  parser->set("$GPRTE,3,3,c,0,FATEA,OCEAI*11");   // jumps to 3, 2 was dropped
+
+  // The broken sequence is discarded; nothing is emitted.
+  TEST_ASSERT_EQUAL_INT(0, rte->waypoints_.get().size());
+  TEST_ASSERT_EQUAL_STRING("", rte->route_id_.get().c_str());
+}
+
+void test_rte_total_mismatch_discards_partial(void) {
+  parser->set("$GPRTE,2,1,c,0,PBRCPK,CPNPT*45");  // first of 2
+  parser->set("$GPRTE,3,2,c,0,FATEA,OCEAI*10");   // claims a different total
+
+  TEST_ASSERT_EQUAL_INT(0, rte->waypoints_.get().size());
+  TEST_ASSERT_EQUAL_STRING("", rte->route_id_.get().c_str());
+}
+
+void test_rte_route_id_change_discards_partial(void) {
+  parser->set("$GPRTE,2,1,c,0,PBRCPK,CPNPT*45");  // first of 2, route 0
+  parser->set("$GPRTE,2,2,c,1,FATEA,OCEAI*10");   // route changed to 1
+
+  TEST_ASSERT_EQUAL_INT(0, rte->waypoints_.get().size());
+  TEST_ASSERT_EQUAL_STRING("", rte->route_id_.get().c_str());
+}
+
+void test_rte_timeout_discards_partial(void) {
+  parser->set("$GPRTE,2,1,c,0,PBRCPK,CPNPT*45");  // first of 2
+  fake_millis += RTESentenceParser::kDefaultSequenceTimeoutMs + 1;
+  parser->set("$GPRTE,2,2,c,0,FATEA,OCEAI*11");   // arrives after the timeout
+
+  TEST_ASSERT_EQUAL_INT(0, rte->waypoints_.get().size());
+  TEST_ASSERT_EQUAL_STRING("", rte->route_id_.get().c_str());
+}
+
+void test_rte_recovers_after_interruption(void) {
+  // A broken sequence must not block a subsequent valid route.
+  parser->set("$GPRTE,2,1,c,0,PBRCPK,CPNPT*45");
+  parser->set("$GPRTE,2,2,c,1,FATEA,OCEAI*10");  // route change breaks it
+
+  parser->set("$GPRTE,1,1,c,ROUTE2,WPA,WPB*5F");
+
+  TEST_ASSERT_EQUAL_STRING("ROUTE2", rte->route_id_.get().c_str());
+  std::vector<String> wps = rte->waypoints_.get();
+  TEST_ASSERT_EQUAL_INT(2, wps.size());
+  TEST_ASSERT_EQUAL_STRING("WPA", wps[0].c_str());
+  TEST_ASSERT_EQUAL_STRING("WPB", wps[1].c_str());
+}
+
 #ifdef ARDUINO
 void setup() {
   delay(2000);
@@ -54,6 +106,11 @@ void setup() {
 
   RUN_TEST(test_rte_single_sentence);
   RUN_TEST(test_rte_multi_sentence);
+  RUN_TEST(test_rte_gap_discards_partial);
+  RUN_TEST(test_rte_total_mismatch_discards_partial);
+  RUN_TEST(test_rte_route_id_change_discards_partial);
+  RUN_TEST(test_rte_timeout_discards_partial);
+  RUN_TEST(test_rte_recovers_after_interruption);
 
   UNITY_END();
 }
@@ -65,6 +122,11 @@ int main(int argc, char** argv) {
 
   RUN_TEST(test_rte_single_sentence);
   RUN_TEST(test_rte_multi_sentence);
+  RUN_TEST(test_rte_gap_discards_partial);
+  RUN_TEST(test_rte_total_mismatch_discards_partial);
+  RUN_TEST(test_rte_route_id_change_discards_partial);
+  RUN_TEST(test_rte_timeout_discards_partial);
+  RUN_TEST(test_rte_recovers_after_interruption);
 
   return UNITY_END();
 }


### PR DESCRIPTION
## Why

`RTESentenceParser` accumulates waypoints across multiple `$xxRTE` sentences. If a sequence was interrupted — a dropped sentence, bus noise, or an interleaved query from another device — the partial state persisted and waypoints from different routes could merge silently.

## What

Discard partial sequence state (rather than merging) on any of four triggers:

- **Continuity** — only `sentence_number == 1` starts a sequence; a continuation that doesn't match the expected next number is dropped.
- **Count mismatch** — a continuation whose `num_sentences` differs from the stored total is dropped.
- **Route-id change** — a continuation with a different route id is dropped.
- **Timeout** — if the gap since the last accepted sentence exceeds the timeout, the partial state is discarded.

Emission happens only when a complete, consistent sequence reaches its last sentence. The timeout is configurable (`kDefaultSequenceTimeoutMs = 5000`) and the clock is injectable (defaults to `millis()`) so the timeout is deterministically testable. The constructor stays backward compatible (`new RTESentenceParser(parser)` still works); the `route_id_` / `waypoints_` observables are unchanged.

## Verification

`test_rte` on a HALMET: **7/7** — the original two cases plus gap, count-mismatch, route-id-change, timeout, and recover-after-interruption.

Stacked on #38 (Nullable migration); will retarget to `main` when that merges. Closes #33.
