### PR TITLE
Add ProprietarySentenceParser base class and fix PSTI field offsets

### DIFF
--- a/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
+++ b/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.cpp
@@ -593,10 +593,10 @@ bool SkyTraqPSTI030SentenceParser::parse_fields(const char* field_strings,
   // Example:
   // $PSTI,030,044606.000,A,2447.0924110,N,12100.5227860,E,103.323,0.00,0.00,0.00,180915,R,1.2,4.2*02
 
-  // note: field offsets are one larger than in the reference because
-  // the subsentence number is at offset 1
+  // The "030" message subtype occupies comma-separated field 1, so the
+  // data fields numbered 1..14 below are read starting from field 2.
 
-  if (num_fields < 15) {
+  if (num_fields < 16) {
     return false;
   }
 
@@ -651,7 +651,7 @@ bool SkyTraqPSTI030SentenceParser::parse_fields(const char* field_strings,
       FLDP(Float, &rtk_ratio)};
 
   for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
-    ok &= fps[i - 1](field_strings + field_offsets[i]);
+    ok &= fps[i - 1](field_strings + field_offsets[i + 1]);
   }
 
   if (!ok) {
@@ -702,10 +702,10 @@ bool SkyTraqPSTI032SentenceParser::parse_fields(const char* field_strings,
   // Example:
   // $PSTI,032,041457.000,170316,A,R,0.603,‐0.837,‐0.089,1.036,144.22,,,,,*30
 
-  // note: field offsets are one larger than in the reference because
-  // the subsentence number is at offset 1
+  // The "032" message subtype occupies comma-separated field 1, so the
+  // data fields numbered 1..9 below are read starting from field 2.
 
-  if (num_fields < 10) {
+  if (num_fields < 11) {
     return false;
   }
 
@@ -749,7 +749,7 @@ bool SkyTraqPSTI032SentenceParser::parse_fields(const char* field_strings,
   };
 
   for (int i = 1; i <= sizeof(fps) / sizeof(fps[0]); i++) {
-    ok &= fps[i - 1](field_strings + field_offsets[i]);
+    ok &= fps[i - 1](field_strings + field_offsets[i + 1]);
   }
 
   if (!ok) {

--- a/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h
+++ b/src/sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h
@@ -6,6 +6,7 @@
 #include "sensesp/types/position.h"
 #include "sensesp_nmea0183/data/gnss_data.h"
 #include "sensesp_nmea0183/nmea0183.h"
+#include "sensesp_nmea0183/sentence_parser/proprietary_sentence_parser.h"
 #include "sensesp_nmea0183/sentence_parser/sentence_parser.h"
 
 namespace sensesp::nmea0183 {
@@ -106,13 +107,13 @@ class GSVSentenceParser : public SentenceParser {
 };
 
 /// Parser for SkyTraq proprietary STI,030 - Recommended Minimum 3D GNSS Data
-class SkyTraqPSTI030SentenceParser : public SentenceParser {
+class SkyTraqPSTI030SentenceParser : public ProprietarySentenceParser {
  public:
-  SkyTraqPSTI030SentenceParser(NMEA0183Parser* nmea) : SentenceParser(nmea) {}
+  SkyTraqPSTI030SentenceParser(NMEA0183Parser* nmea)
+      : ProprietarySentenceParser(nmea, "PSTI,030") {}
 
   bool parse_fields(const char* field_strings, const int field_offsets[],
                     int num_fields) override final;
-  const char* sentence_address() override { return "PSTI,030"; }
 
   ObservableValue<Position> position_;
   ObservableValue<time_t> datetime_;
@@ -123,13 +124,13 @@ class SkyTraqPSTI030SentenceParser : public SentenceParser {
 };
 
 /// Parser for SkyTraq proprietary STI,032 - RTK Baseline Data
-class SkyTraqPSTI032SentenceParser : public SentenceParser {
+class SkyTraqPSTI032SentenceParser : public ProprietarySentenceParser {
  public:
-  SkyTraqPSTI032SentenceParser(NMEA0183Parser* nmea) : SentenceParser(nmea) {}
+  SkyTraqPSTI032SentenceParser(NMEA0183Parser* nmea)
+      : ProprietarySentenceParser(nmea, "PSTI,032") {}
 
   bool parse_fields(const char* field_strings, const int field_offsets[],
                     int num_fields) override final;
-  const char* sentence_address() override { return "PSTI,032"; }
 
   ObservableValue<time_t> datetime_;
   ObservableValue<ENUVector> baseline_projection_;
@@ -139,13 +140,13 @@ class SkyTraqPSTI032SentenceParser : public SentenceParser {
 };
 
 /// Parser for Quectel proprietary PQTMTAR - Time and Attitude
-class QuectelPQTMTARSentenceParser : public SentenceParser {
+class QuectelPQTMTARSentenceParser : public ProprietarySentenceParser {
  public:
-  QuectelPQTMTARSentenceParser(NMEA0183Parser* nmea) : SentenceParser(nmea) {}
+  QuectelPQTMTARSentenceParser(NMEA0183Parser* nmea)
+      : ProprietarySentenceParser(nmea, "PQTMTAR") {}
 
   bool parse_fields(const char* field_strings, const int field_offsets[],
                     int num_fields) override final;
-  const char* sentence_address() override { return "PQTMTAR"; }
 
   ObservableValue<time_t> datetime_;
   ObservableValue<String> rtk_quality_;

--- a/src/sensesp_nmea0183/sentence_parser/proprietary_sentence_parser.h
+++ b/src/sensesp_nmea0183/sentence_parser/proprietary_sentence_parser.h
@@ -1,0 +1,37 @@
+#ifndef SENSESP_NMEA0183_PROPRIETARY_SENTENCE_PARSER_H_
+#define SENSESP_NMEA0183_PROPRIETARY_SENTENCE_PARSER_H_
+
+#include "sensesp_nmea0183/sentence_parser/sentence_parser.h"
+
+namespace sensesp::nmea0183 {
+
+/**
+ * @brief Base class for proprietary NMEA 0183 sentence parsers.
+ *
+ * Proprietary sentences carry a "$P" prefix followed by a manufacturer
+ * mnemonic and a message type, e.g. "$PSTI,030,..." (SkyTraq) or
+ * "$PQTMTAR,..." (Quectel). Subclasses supply the sentence address at
+ * construction instead of overriding sentence_address(); the address is
+ * matched against the sentence tail by the dispatcher and must cover
+ * everything up to (but not including) the first data field.
+ *
+ * Comma-separated fields are numbered from the sentence start with the
+ * address in field 0. When the message type is a separate comma-delimited
+ * token (as in "$PSTI,030") it occupies field 1, so the first data field is
+ * field 2; addresses without an embedded comma (as in "$PQTMTAR") keep the
+ * first data field at field 1.
+ */
+class ProprietarySentenceParser : public SentenceParser {
+ public:
+  ProprietarySentenceParser(NMEA0183Parser* nmea, const char* address)
+      : SentenceParser(nmea), address_(address) {}
+
+  const char* sentence_address() override final { return address_; }
+
+ private:
+  const char* address_;
+};
+
+}  // namespace sensesp::nmea0183
+
+#endif  // SENSESP_NMEA0183_PROPRIETARY_SENTENCE_PARSER_H_

--- a/test/test_proprietary/test_proprietary.cpp
+++ b/test/test_proprietary/test_proprietary.cpp
@@ -1,0 +1,122 @@
+#include <unity.h>
+
+#include "sensesp/types/position.h"
+#include "sensesp_nmea0183/nmea0183.h"
+#include "sensesp_nmea0183/sentence_parser/gnss_sentence_parser.h"
+
+using namespace sensesp;
+using namespace sensesp::nmea0183;
+
+static NMEA0183Parser* parser;
+static SkyTraqPSTI030SentenceParser* psti030;
+static SkyTraqPSTI032SentenceParser* psti032;
+static QuectelPQTMTARSentenceParser* pqtmtar;
+
+void setUp(void) {
+  parser = new NMEA0183Parser();
+  psti030 = new SkyTraqPSTI030SentenceParser(parser);
+  psti032 = new SkyTraqPSTI032SentenceParser(parser);
+  pqtmtar = new QuectelPQTMTARSentenceParser(parser);
+}
+
+void tearDown(void) {
+  delete pqtmtar;
+  delete psti032;
+  delete psti030;
+  delete parser;
+}
+
+// SkyTraq PSTI,030 — Recommended Minimum 3D GNSS Data.
+// Fields after the "$PSTI,030" address: UTC time, status, lat, N/S, lon, E/W,
+// altitude, E/N/U velocity, UTC date, mode, RTK age, RTK ratio.
+void test_psti030_full(void) {
+  parser->set(
+      "$PSTI,030,044606.000,A,2447.0924110,N,12100.5227860,E,103.323,0.00,0.00,"
+      "0.00,180915,R,1.2,4.2*02");
+
+  TEST_ASSERT_EQUAL_INT(1, psti030->get_rx_count());
+  TEST_ASSERT_EQUAL_STRING("RTK fixed integer",
+                           psti030->gnss_quality_.get().c_str());
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 1.2, psti030->rtk_age_.get());
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 4.2, psti030->rtk_ratio_.get());
+
+  Position pos = psti030->position_.get();
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, 24.784873, pos.latitude);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, 121.008713, pos.longitude);
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 103.323, pos.altitude);
+
+  ENUVector vel = psti030->enu_velocity_.get();
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 0.0, vel.east);
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 0.0, vel.north);
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 0.0, vel.up);
+}
+
+// SkyTraq PSTI,032 — RTK Baseline Data.
+// Fields after the "$PSTI,032" address: UTC time, UTC date, status, mode,
+// E/N/U baseline projection, baseline length, baseline course.
+void test_psti032_full(void) {
+  parser->set(
+      "$PSTI,032,041457.000,170316,A,R,0.603,-0.837,-0.089,1.036,144.22,,,,,"
+      "*1C");
+
+  TEST_ASSERT_EQUAL_INT(1, psti032->get_rx_count());
+  TEST_ASSERT_EQUAL_STRING("RTK fixed integer",
+                           psti032->gnss_quality_.get().c_str());
+  TEST_ASSERT_FLOAT_WITHIN(0.01, 1.036, psti032->baseline_length_.get());
+  // Baseline course is reported in radians (144.22 degrees).
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 2.51711, psti032->baseline_course_.get());
+
+  ENUVector proj = psti032->baseline_projection_.get();
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 0.603, proj.east);
+  TEST_ASSERT_FLOAT_WITHIN(0.001, -0.837, proj.north);
+  TEST_ASSERT_FLOAT_WITHIN(0.001, -0.089, proj.up);
+}
+
+// Quectel PQTMTAR — Time and Attitude (heading status 4 = RTK fixed).
+// Attitude angles are reported in degrees.
+void test_pqtmtar_attitude(void) {
+  parser->set(
+      "$PQTMTAR,1,165331.000,4,,0.232,2.321340,-6.849396,80.410065,0.081330,"
+      "0.045079,0.054334,00*70");
+
+  TEST_ASSERT_EQUAL_INT(1, pqtmtar->get_rx_count());
+  TEST_ASSERT_EQUAL_STRING("RTK fixed integer",
+                           pqtmtar->rtk_quality_.get().c_str());
+  TEST_ASSERT_EQUAL_INT(0, pqtmtar->hdg_num_satellites_.get());
+  TEST_ASSERT_FLOAT_WITHIN(0.001, 0.232, pqtmtar->baseline_length_.get());
+
+  AttitudeVector att = pqtmtar->attitude_.get();
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, 2.321340, att.pitch);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, -6.849396, att.roll);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, 80.410065, att.yaw);
+
+  AttitudeVector acc = pqtmtar->attitude_accuracy_.get();
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, 0.081330, acc.pitch);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, 0.045079, acc.roll);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001, 0.054334, acc.yaw);
+}
+
+#ifdef ARDUINO
+void setup() {
+  delay(2000);
+  UNITY_BEGIN();
+
+  RUN_TEST(test_psti030_full);
+  RUN_TEST(test_psti032_full);
+  RUN_TEST(test_pqtmtar_attitude);
+
+  UNITY_END();
+}
+
+void loop() {}
+#else
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_psti030_full);
+  RUN_TEST(test_psti032_full);
+  RUN_TEST(test_pqtmtar_attitude);
+
+  return UNITY_END();
+}
+#endif


### PR DESCRIPTION
## Why

The three proprietary parsers (`SkyTraqPSTI030`, `SkyTraqPSTI032`, `QuectelPQTMTAR`) each reimplemented the full `SentenceParser` interface with a hardcoded address. Issue #34 asked for a cleaner extension point for the shared `$P<manufacturer><type>` structure. Writing characterization tests for them (there were none) also surfaced a real bug.

## What

- **`ProprietarySentenceParser` base class** — subclasses pass their address at construction instead of each overriding `sentence_address()`, and the class is the documented home for the proprietary field-numbering convention. Deliberately minimal: no manufacturer-routing layer. With three parsers and an address-matching dispatcher that already routes correctly, a routing table would be indirection that only pays off with many more parsers. The decode logic in all three parsers is unchanged.

- **Fix PSTI030/PSTI032 field offsets** (pre-existing bug the new tests caught). The `PSTI,030` / `PSTI,032` addresses contain an embedded comma, so the message subtype is field 1 and the first real data field is field 2 — but the parsers read from field 1. `ParseTime` ran on `"030"`, failed, and the sentence was dropped: **these parsers emitted nothing for valid sentences.** Reading now starts at the correct offset, with the minimum field-count checks raised to match. `QuectelPQTMTAR` was already correct (no embedded comma) and is untouched.

## Verification

`test_proprietary` on a HALMET: **3/3** (PSTI030, PSTI032, PQTMTAR). Full suite on this branch: **47/47**, confirming the reparenting and the GNSS regression suites are unaffected.

Stacked on #38 (Nullable migration); will retarget to `main` when that merges. Closes #34.
